### PR TITLE
Feature/raw signals panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -113,7 +113,7 @@
   border: 1px solid rgba(119, 184, 132, 0.38);
   border-radius: 2px;
   background: var(--control-surface);
-  color: rgba(167, 213, 173, 0.9);
+  color: var(--status-live-bright);
   font-size: 0.9rem;
   font-weight: 560;
   padding: 9px 12px;
@@ -124,7 +124,7 @@
   background:
     linear-gradient(180deg, rgba(119, 184, 132, 0.11), rgba(51, 242, 240, 0.035)),
     var(--control-surface);
-  color: #a7d5ad;
+  color: var(--status-live-bright);
 }
 
 .command-workbench {
@@ -351,13 +351,34 @@
 }
 
 .mission-summary {
+  --mission-state-bg: rgba(224, 92, 79, 0.12);
+  --mission-state-border: rgba(224, 92, 79, 0.58);
+  --mission-state-text: #ff7b6d;
   display: grid;
   gap: 12px;
   padding: 12px;
-  border-color: rgba(224, 92, 79, 0.44);
+  border-color: var(--mission-state-border);
   background:
-    linear-gradient(135deg, rgba(224, 92, 79, 0.12), rgba(51, 242, 240, 0.035) 44%, transparent),
+    linear-gradient(135deg, var(--mission-state-bg), rgba(51, 242, 240, 0.035) 44%, transparent),
     rgba(2, 4, 4, 0.92);
+}
+
+.mission-summary--white {
+  --mission-state-bg: rgba(245, 247, 240, 0.06);
+  --mission-state-border: rgba(245, 247, 240, 0.28);
+  --mission-state-text: var(--status-white);
+}
+
+.mission-summary--amber {
+  --mission-state-bg: rgba(201, 164, 87, 0.12);
+  --mission-state-border: rgba(201, 164, 87, 0.52);
+  --mission-state-text: var(--status-amber);
+}
+
+.mission-summary--red {
+  --mission-state-bg: rgba(224, 92, 79, 0.13);
+  --mission-state-border: rgba(224, 92, 79, 0.62);
+  --mission-state-text: #ff7b6d;
 }
 
 .mission-summary > *,
@@ -377,10 +398,10 @@
 }
 
 .mission-summary__topline strong {
-  border: 1px solid rgba(224, 92, 79, 0.58);
+  border: 1px solid var(--mission-state-border);
   border-radius: 2px;
-  background: rgba(216, 166, 58, 0.08);
-  color: #ff7b6d;
+  background: var(--mission-state-bg);
+  color: var(--mission-state-text);
   font-size: 0.86rem;
   font-weight: 650;
   padding: 5px 10px;
@@ -1137,7 +1158,7 @@
 
 .aor-map__scale {
   right: 14px;
-  bottom: 82px;
+  bottom: 54px;
   display: flex;
   gap: 14px;
   padding: 8px 10px;
@@ -1495,17 +1516,49 @@
 }
 
 .event-feed__status {
+  --event-status-bg: rgba(51, 242, 240, 0.06);
+  --event-status-border: rgba(51, 242, 240, 0.26);
+  --event-status-text: rgba(51, 242, 240, 0.84);
   display: inline-flex;
   align-items: center;
   gap: 8px;
 }
 
 .event-feed__status span {
-  border: 1px solid rgba(201, 164, 87, 0.34);
-  background: rgba(201, 164, 87, 0.08);
-  color: #e1c879;
+  border: 1px solid var(--event-status-border);
+  background: var(--event-status-bg);
+  color: var(--event-status-text);
   padding: 3px 6px;
   font-size: 0.6rem;
+}
+
+.event-feed__status strong {
+  color: var(--event-status-text);
+}
+
+.event-feed__status--priority {
+  --event-status-bg: rgba(224, 92, 79, 0.09);
+  --event-status-border: rgba(224, 92, 79, 0.44);
+  --event-status-text: #ff7b6d;
+}
+
+.event-feed__status--watch {
+  --event-status-bg: rgba(201, 164, 87, 0.08);
+  --event-status-border: rgba(201, 164, 87, 0.34);
+  --event-status-text: #e1c879;
+}
+
+.event-feed__status--monitor,
+.event-feed__status--demo {
+  --event-status-bg: rgba(51, 242, 240, 0.055);
+  --event-status-border: rgba(51, 242, 240, 0.28);
+  --event-status-text: rgba(51, 242, 240, 0.84);
+}
+
+.event-feed__status--live {
+  --event-status-bg: rgba(119, 184, 132, 0.09);
+  --event-status-border: rgba(119, 184, 132, 0.4);
+  --event-status-text: var(--status-live-bright);
 }
 
 .event-feed__stream {
@@ -1649,6 +1702,283 @@
 }
 
 .event-feed__confidence {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.event-feed__header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.event-feed__tabs {
+  display: flex;
+  overflow: hidden;
+  border: 1px solid rgba(220, 227, 213, 0.16);
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.event-feed__tab {
+  min-height: 28px;
+  border: 0;
+  border-right: 1px solid rgba(220, 227, 213, 0.14);
+  background: transparent;
+  color: rgba(245, 247, 240, 0.66);
+  font: inherit;
+  font-size: 0.62rem;
+  font-weight: 760;
+  padding: 5px 9px;
+}
+
+.event-feed__tab:last-child {
+  border-right: 0;
+}
+
+.event-feed__tab:hover,
+.event-feed__tab.is-active {
+  background:
+    linear-gradient(180deg, rgba(51, 242, 240, 0.11), rgba(51, 242, 240, 0.02)),
+    rgba(14, 34, 34, 0.58);
+  color: #b8fbf7;
+}
+
+.event-feed__focus-toggle {
+  min-height: 28px;
+  border: 1px solid rgba(220, 227, 213, 0.16);
+  background: rgba(0, 0, 0, 0.28);
+  color: rgba(245, 247, 240, 0.62);
+  font: inherit;
+  font-size: 0.62rem;
+  font-weight: 760;
+  padding: 5px 9px;
+  white-space: nowrap;
+}
+
+.event-feed__focus-toggle:hover,
+.event-feed__focus-toggle.is-active {
+  border-color: rgba(224, 92, 79, 0.38);
+  background:
+    linear-gradient(180deg, rgba(224, 92, 79, 0.12), rgba(224, 92, 79, 0.03)),
+    rgba(42, 24, 22, 0.58);
+  color: #ffb8ae;
+}
+
+.event-feed__raw-view {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: #070a0c;
+}
+
+.event-feed__bus-status {
+  display: grid;
+  grid-template-columns: auto auto auto auto auto auto minmax(64px, 120px);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 6px 8px;
+  border-bottom: 1px solid rgba(220, 227, 213, 0.12);
+  color: rgba(201, 209, 217, 0.62);
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.event-feed__bus-status span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.event-feed__bus-status strong {
+  color: var(--status-live-bright);
+  font-weight: 760;
+}
+
+.event-feed__live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-live);
+  box-shadow: 0 0 10px rgba(121, 210, 140, 0.62);
+}
+
+.event-feed__sparkline {
+  display: flex;
+  align-items: end;
+  justify-content: flex-end;
+  gap: 1px;
+  height: 16px;
+  min-width: 0;
+}
+
+.event-feed__sparkline i {
+  width: 3px;
+  height: var(--bar-height);
+  min-height: 2px;
+  background: rgba(51, 242, 240, 0.42);
+}
+
+.event-feed__stream--raw {
+  gap: 0;
+  padding: 0;
+  background: #070a0c;
+  font-family: var(--font-mono);
+}
+
+.event-feed__raw-entry {
+  border-bottom: 1px solid rgba(220, 227, 213, 0.08);
+  border-left: 2px solid rgba(51, 242, 240, 0.44);
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.event-feed__raw-entry[data-newest='true'] {
+  background:
+    linear-gradient(90deg, rgba(201, 164, 87, 0.12), transparent 42%),
+    rgba(0, 0, 0, 0.48);
+}
+
+.event-feed__raw-entry--high {
+  border-left-color: var(--red);
+}
+
+.event-feed__raw-entry--watch {
+  border-left-color: var(--amber);
+}
+
+.event-feed__raw-entry--low {
+  border-left-color: rgba(51, 242, 240, 0.44);
+}
+
+.event-feed__raw-entry[data-domain='rf_ew'] {
+  --domain-color: var(--domain-rf-ew);
+}
+
+.event-feed__raw-entry[data-domain='cyber'] {
+  --domain-color: var(--domain-cyber);
+}
+
+.event-feed__raw-entry[data-domain='pnt'] {
+  --domain-color: var(--domain-pnt);
+}
+
+.event-feed__raw-entry[data-domain='sda'],
+.event-feed__raw-entry[data-domain='satcom'],
+.event-feed__raw-entry[data-domain='orbit'] {
+  --domain-color: var(--domain-space);
+}
+
+.event-feed__raw-entry[data-domain='drone'] {
+  --domain-color: var(--domain-drone);
+}
+
+.event-feed__raw-entry[data-domain='osint'],
+.event-feed__raw-entry[data-domain='humint'],
+.event-feed__raw-entry[data-domain='terrain'] {
+  --domain-color: var(--domain-context);
+}
+
+.event-feed__raw-row {
+  display: grid;
+  grid-template-columns: 74px 70px 120px minmax(0, 1fr) 72px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 24px;
+  border: 0;
+  background: transparent;
+  color: rgba(201, 209, 217, 0.86);
+  font: inherit;
+  font-size: 0.62rem;
+  line-height: 1;
+  padding: 5px 8px 5px 7px;
+  text-align: left;
+}
+
+.event-feed__raw-row:hover {
+  background: rgba(51, 242, 240, 0.055);
+}
+
+.event-feed__raw-row span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-feed__raw-time,
+.event-feed__raw-source,
+.event-feed__raw-confidence {
+  color: rgba(201, 209, 217, 0.52);
+}
+
+.event-feed__raw-domain {
+  color: var(--domain-color, rgba(51, 242, 240, 0.82));
+  font-weight: 760;
+}
+
+.event-feed__raw-payload {
+  color: rgba(245, 247, 240, 0.82);
+}
+
+.event-feed__raw-detail {
+  max-height: 150px;
+  margin: 0;
+  overflow: auto;
+  border-top: 1px solid rgba(220, 227, 213, 0.1);
+  background: rgba(0, 0, 0, 0.68);
+  color: rgba(245, 247, 240, 0.76);
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  line-height: 1.28;
+  padding: 8px 10px;
+  white-space: pre-wrap;
+}
+
+.event-feed__raw-detail code {
+  font: inherit;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .event-feed__raw-entry[data-newest='true'] {
+    animation: event-raw-flash 180ms ease-out;
+  }
+
+  .event-feed__live-dot {
+    animation: event-live-pulse 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes event-raw-flash {
+  from {
+    background:
+      linear-gradient(90deg, rgba(201, 164, 87, 0.22), transparent 48%),
+      rgba(0, 0, 0, 0.58);
+  }
+
+  to {
+    background:
+      linear-gradient(90deg, rgba(201, 164, 87, 0.12), transparent 42%),
+      rgba(0, 0, 0, 0.48);
+  }
+}
+
+@keyframes event-live-pulse {
+  0%,
+  100% {
+    opacity: 0.62;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+.event-feed__empty {
+  margin: 0;
   color: var(--text-muted);
   font-size: 0.72rem;
 }
@@ -1904,7 +2234,7 @@
 
   .aor-map__scale {
     right: 310px;
-    bottom: 230px;
+    bottom: 262px;
   }
 
   .aor-map__legend {

--- a/src/components/CesiumGlobe.tsx
+++ b/src/components/CesiumGlobe.tsx
@@ -798,6 +798,8 @@ export function CesiumGlobe({
         ),
         duration: 0.6,
       })
+    } else if (!focusSignalId) {
+      focusFlightSignalIdRef.current = null
     }
 
     viewer.scene.requestRender()

--- a/src/components/CesiumGlobe.tsx
+++ b/src/components/CesiumGlobe.tsx
@@ -583,7 +583,6 @@ export function CesiumGlobe({
         position: Cartesian3.fromDegrees(contact.lon, contact.lat, contact.height),
         billboard: {
           color: Color.WHITE,
-          disableDepthTestDistance: Number.POSITIVE_INFINITY,
           height: 20,
           image: markerSvg('drone', markerColorHex(contact.color)),
           scaleByDistance: new NearFarScalar(50000, 0.82, 900000, 0.42),
@@ -591,7 +590,6 @@ export function CesiumGlobe({
         },
         label: {
           backgroundColor: MAP_PANEL.withAlpha(0.82),
-          disableDepthTestDistance: Number.POSITIVE_INFINITY,
           fillColor: Color.WHITE,
           font: MAP_FONT,
           pixelOffset: new Cartesian2(0, -28),
@@ -609,7 +607,6 @@ export function CesiumGlobe({
         position: Cartesian3.fromDegrees(contact.lon, contact.lat, contact.height),
         billboard: {
           color: Color.WHITE,
-          disableDepthTestDistance: Number.POSITIVE_INFINITY,
           height: 20,
           image: markerSvg('satellite', markerColorHex(contact.color)),
           scaleByDistance: new NearFarScalar(1500000, 0.86, 25000000, 0.38),
@@ -617,7 +614,6 @@ export function CesiumGlobe({
         },
         label: {
           backgroundColor: MAP_PANEL.withAlpha(0.82),
-          disableDepthTestDistance: Number.POSITIVE_INFINITY,
           fillColor: Color.WHITE,
           font: MAP_FONT,
           pixelOffset: new Cartesian2(0, -22),
@@ -692,7 +688,6 @@ export function CesiumGlobe({
           position: Cartesian3.fromDegrees(point.lon, point.lat, point.height),
           billboard: {
             color: Color.WHITE,
-            disableDepthTestDistance: Number.POSITIVE_INFINITY,
             height: isFocus ? 24 : isCorrelated ? 21 : 18,
             image: markerSvg(markerKind, markerColorHex(color)),
             scaleByDistance: new NearFarScalar(1500000, 0.84, 25000000, 0.36),
@@ -700,7 +695,6 @@ export function CesiumGlobe({
           },
           label: {
             backgroundColor: MAP_PANEL.withAlpha(0.84),
-            disableDepthTestDistance: Number.POSITIVE_INFINITY,
             fillColor: Color.WHITE,
             font: MAP_FONT,
             pixelOffset: new Cartesian2(0, -28),

--- a/src/components/EventFeed.tsx
+++ b/src/components/EventFeed.tsx
@@ -1,17 +1,159 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
 import type { Signal } from '../types/canopy'
 import { commanderSignalSummary } from '../lib/commanderLanguage'
 
 type EventFeedProps = {
+  isMapAutoFocusEnabled?: boolean
+  isLive?: boolean
+  onToggleMapAutoFocus?: () => void
   signals: Signal[]
 }
 
-export function EventFeed({ signals }: EventFeedProps) {
+type FeedView = 'updates' | 'raw'
+
+const RAW_SIGNAL_LIMIT = 30
+const SPARKLINE_BUCKETS = 24
+const ONE_MINUTE_MS = 60_000
+
+const priorityForSignal = (signal: Signal) =>
+  signal.confidence >= 0.86
+    ? 'high'
+    : signal.confidence >= 0.74
+      ? 'watch'
+      : 'low'
+
+const signalEnvelope = (signal: Signal) => ({
+  type: 'signal',
+  data: signal,
+})
+
+const signalJson = (signal: Signal) =>
+  JSON.stringify(signalEnvelope(signal), null, 2)
+
+const formatTime = (ts: string, includeSeconds = false) =>
+  new Date(ts).toLocaleTimeString([], {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: includeSeconds ? '2-digit' : undefined,
+  })
+
+const compactSource = (source: string) =>
+  source
+    .replace(/^brigade-/i, 'bde-')
+    .replace(/^canopy-/i, 'canopy-')
+    .replace(/controller/gi, 'ctrl')
+    .replace(/commercial/gi, 'com')
+    .replace(/\s+/g, '_')
+    .toLowerCase()
+
+const compactPayload = (signal: Signal) => {
+  const eventType = signal.payload.event_type
+  const asset = signal.payload.asset
+  const summary = signal.payload.summary
+  const fragments = [eventType, asset, summary].filter(Boolean)
+
+  if (fragments.length) {
+    return fragments.join(' | ')
+  }
+
+  return signal.source
+}
+
+const sparklineBuckets = (arrivalTimes: number[]) => {
+  const now = Date.now()
+  const bucketWidth = ONE_MINUTE_MS / SPARKLINE_BUCKETS
+  const buckets = Array.from({ length: SPARKLINE_BUCKETS }, () => 0)
+
+  arrivalTimes.forEach((arrivalTime) => {
+    const age = now - arrivalTime
+    if (age < 0 || age > ONE_MINUTE_MS) {
+      return
+    }
+
+    const bucketIndex = Math.min(
+      SPARKLINE_BUCKETS - 1,
+      Math.floor(age / bucketWidth),
+    )
+    buckets[SPARKLINE_BUCKETS - 1 - bucketIndex] += 1
+  })
+
+  const peak = Math.max(1, ...buckets)
+  return buckets.map((count) => Math.max(10, Math.round((count / peak) * 100)))
+}
+
+export function EventFeed({
+  isMapAutoFocusEnabled = false,
+  isLive = false,
+  onToggleMapAutoFocus,
+  signals,
+}: EventFeedProps) {
+  const [activeView, setActiveView] = useState<FeedView>('updates')
+  const [selectedSignalId, setSelectedSignalId] = useState<string | null>(null)
+  const [arrivalTimes, setArrivalTimes] = useState<number[]>([])
+  const arrivalTimesByIdRef = useRef<Map<string, number>>(new Map())
+  const rawStreamRef = useRef<HTMLDivElement>(null)
+  const latestSignalId = signals[0]?.id
+
+  useEffect(() => {
+    const now = Date.now()
+    const signalIds = new Set(signals.map((signal) => signal.id))
+    const arrivals = arrivalTimesByIdRef.current
+
+    signals.forEach((signal) => {
+      if (!arrivals.has(signal.id)) {
+        arrivals.set(signal.id, now)
+      }
+    })
+
+    arrivals.forEach((arrivalTime, signalId) => {
+      if (now - arrivalTime > ONE_MINUTE_MS && !signalIds.has(signalId)) {
+        arrivals.delete(signalId)
+      }
+    })
+
+    setArrivalTimes(
+      Array.from(arrivals.values()).filter(
+        (arrivalTime) => now - arrivalTime <= ONE_MINUTE_MS,
+      ),
+    )
+  }, [signals])
+
+  useEffect(() => {
+    if (activeView === 'raw') {
+      rawStreamRef.current?.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      })
+    }
+  }, [activeView, latestSignalId])
+
+  const rawSignals = useMemo(
+    () => signals.slice(0, RAW_SIGNAL_LIMIT),
+    [signals],
+  )
+  const activeDomains = useMemo(
+    () => new Set(signals.map((signal) => signal.domain)).size,
+    [signals],
+  )
+  const eventRateBuckets = useMemo(
+    () => sparklineBuckets(arrivalTimes),
+    [arrivalTimes],
+  )
+
   const feedState =
     signals[0]?.confidence >= 0.86
       ? 'PRIORITY'
       : signals[0]?.confidence >= 0.74
         ? 'WATCH'
         : 'MONITOR'
+  const statusTone =
+    activeView === 'raw'
+      ? isLive
+        ? 'live'
+        : 'demo'
+      : feedState.toLowerCase()
 
   return (
     <section className="event-feed" aria-label="Incoming signals">
@@ -20,56 +162,185 @@ export function EventFeed({ signals }: EventFeedProps) {
           <span>ISR / EW / CSM</span>
           <h2>Signal Stream</h2>
         </div>
-        <div className="event-feed__status">
-          <span>{feedState}</span>
-          <strong>{signals.length.toString().padStart(2, '0')}</strong>
+        <div className="event-feed__header-actions">
+          <div
+            className="event-feed__tabs"
+            role="tablist"
+            aria-label="Signal stream view"
+          >
+            <button
+              className={
+                activeView === 'updates'
+                  ? 'event-feed__tab is-active'
+                  : 'event-feed__tab'
+              }
+              onClick={() => setActiveView('updates')}
+              role="tab"
+              type="button"
+              aria-selected={activeView === 'updates'}
+            >
+              Updates
+            </button>
+            <button
+              className={
+                activeView === 'raw'
+                  ? 'event-feed__tab is-active'
+                  : 'event-feed__tab'
+              }
+              onClick={() => setActiveView('raw')}
+              role="tab"
+              type="button"
+              aria-selected={activeView === 'raw'}
+            >
+              Raw Tail
+            </button>
+          </div>
+          {onToggleMapAutoFocus ? (
+            <button
+              className={
+                isMapAutoFocusEnabled
+                  ? 'event-feed__focus-toggle is-active'
+                  : 'event-feed__focus-toggle'
+              }
+              onClick={onToggleMapAutoFocus}
+              type="button"
+              aria-pressed={isMapAutoFocusEnabled}
+              title="Follow high-priority map events"
+            >
+              Map focus
+            </button>
+          ) : null}
+          <div className={`event-feed__status event-feed__status--${statusTone}`}>
+            <span>
+              {activeView === 'raw'
+                ? isLive
+                  ? 'LIVE BUS'
+                  : 'DEMO BUS'
+                : feedState}
+            </span>
+            <strong>{signals.length.toString().padStart(2, '0')}</strong>
+          </div>
         </div>
       </div>
-      <div
-        className="event-feed__stream"
-        role="log"
-        aria-label="Live signal stream"
-        aria-live="polite"
-      >
-        {signals.slice(0, 10).map((signal, index) => {
-          const summary = commanderSignalSummary(signal)
-          const priority =
-            signal.confidence >= 0.86
-              ? 'high'
-              : signal.confidence >= 0.74
-                ? 'watch'
-                : 'low'
-          return (
-            <article
-              className={`event-feed__entry event-feed__entry--${priority}`}
-              data-newest={index === 0 ? 'true' : undefined}
-              key={signal.id}
+
+      {activeView === 'updates' ? (
+        <div
+          className="event-feed__stream"
+          role="log"
+          aria-label="Live signal stream"
+          aria-live="polite"
+        >
+          {signals.slice(0, 10).map((signal, index) => {
+            const summary = commanderSignalSummary(signal)
+            const priority = priorityForSignal(signal)
+            return (
+              <article
+                className={`event-feed__entry event-feed__entry--${priority}`}
+                data-newest={index === 0 ? 'true' : undefined}
+                key={signal.id}
+              >
+                <div className="event-feed__entry-top">
+                  <span className="event-feed__time">
+                    {formatTime(signal.ts)}
+                  </span>
+                  <span className="event-feed__domain">{summary.label}</span>
+                  <span className="event-feed__confidence">
+                    {summary.confidenceLabel}
+                  </span>
+                </div>
+                <div className="event-feed__meaning">
+                  <strong>{summary.headline}</strong>
+                  <p>{summary.whyItMatters}</p>
+                </div>
+                <div className="event-feed__entry-meta">
+                  <span>{summary.location}</span>
+                  <span>{summary.action}</span>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      ) : (
+        <div className="event-feed__raw-view">
+          <div className="event-feed__bus-status">
+            <span className="event-feed__live-dot" aria-hidden="true" />
+            <span>canopy://bus</span>
+            <span>signals.* topics</span>
+            <span>{arrivalTimes.length} events/min</span>
+            <span>{activeDomains} domains active</span>
+            <strong>{isLive ? 'live' : 'demo'}</strong>
+            <div
+              className="event-feed__sparkline"
+              aria-label="Event rate over the last minute"
             >
-              <div className="event-feed__entry-top">
-                <span className="event-feed__time">
-                  {new Date(signal.ts).toLocaleTimeString([], {
-                    hour12: false,
-                    hour: '2-digit',
-                    minute: '2-digit',
-                  })}
-                </span>
-                <span className="event-feed__domain">{summary.label}</span>
-                <span className="event-feed__confidence">
-                  {summary.confidenceLabel}
-                </span>
-              </div>
-              <div className="event-feed__meaning">
-                <strong>{summary.headline}</strong>
-                <p>{summary.whyItMatters}</p>
-              </div>
-              <div className="event-feed__entry-meta">
-                <span>{summary.location}</span>
-                <span>{summary.action}</span>
-              </div>
-            </article>
-          )
-        })}
-      </div>
+              {eventRateBuckets.map((height, index) => (
+                <i
+                  key={`${height}-${index}`}
+                  style={{ '--bar-height': `${height}%` } as CSSProperties}
+                />
+              ))}
+            </div>
+          </div>
+          <div
+            className="event-feed__stream event-feed__stream--raw"
+            ref={rawStreamRef}
+            role="log"
+            aria-label="Raw signal live tail"
+            aria-live="polite"
+          >
+            {rawSignals.length ? (
+              rawSignals.map((signal, index) => {
+                const priority = priorityForSignal(signal)
+                const isNewest = index === 0
+                const isSelected = signal.id === selectedSignalId
+
+                return (
+                  <article
+                    className={`event-feed__raw-entry event-feed__raw-entry--${priority}`}
+                    data-newest={isNewest ? 'true' : undefined}
+                    data-domain={signal.domain}
+                    key={signal.id}
+                  >
+                    <button
+                      className="event-feed__raw-row"
+                      onClick={() =>
+                        setSelectedSignalId(isSelected ? null : signal.id)
+                      }
+                      type="button"
+                      aria-expanded={isSelected}
+                    >
+                      <span className="event-feed__raw-time">
+                        {formatTime(signal.ts, true)}
+                      </span>
+                      <span className="event-feed__raw-domain">
+                        {signal.domain}
+                      </span>
+                      <span className="event-feed__raw-source">
+                        {compactSource(signal.source)}
+                      </span>
+                      <span className="event-feed__raw-payload">
+                        {compactPayload(signal)}
+                      </span>
+                      <span className="event-feed__raw-confidence">
+                        conf={signal.confidence.toFixed(2)}
+                      </span>
+                    </button>
+                    {isSelected ? (
+                      <pre className="event-feed__raw-detail">
+                        <code>{signalJson(signal)}</code>
+                      </pre>
+                    ) : null}
+                  </article>
+                )
+              })
+            ) : (
+              <p className="event-feed__empty">
+                Waiting for signal envelopes...
+              </p>
+            )}
+          </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/src/components/MissionSummary.tsx
+++ b/src/components/MissionSummary.tsx
@@ -36,9 +36,13 @@ export function MissionSummary({
   const action = uiEvent
     ? commanderBrief.action
     : decision?.action ?? commanderBrief.action
+  const stateClass = state.toLowerCase()
 
   return (
-    <section className="mission-summary" aria-label="Mission summary">
+    <section
+      className={`mission-summary mission-summary--${stateClass}`}
+      aria-label="Mission summary"
+    >
       <div className="mission-summary__topline">
         <span>Posture</span>
         <strong>{state}</strong>

--- a/src/hooks/useCanopyMissionState.ts
+++ b/src/hooks/useCanopyMissionState.ts
@@ -24,6 +24,11 @@ export type CanopyMissionState = {
   latestUiEvent: UIEvent | null
 }
 
+type MissionStateOptions = {
+  enableMapAutoFocus?: boolean
+  mapFocusMinConfidence?: number
+}
+
 const spaceDomains = new Set<Domain>(['orbit', 'sda'])
 const commsDomains = new Set<Domain>([
   'satcom',
@@ -101,14 +106,25 @@ const statusForSignals = (
 export function useCanopyMissionState(
   signals: Signal[],
   uiEvents: UIEvent[],
+  {
+    enableMapAutoFocus = true,
+    mapFocusMinConfidence = 0.86,
+  }: MissionStateOptions = {},
 ): CanopyMissionState {
   return useMemo(() => {
     const latestUiEvent = uiEvents[0] ?? null
     const correlatedSignalIds = new Set(latestUiEvent?.source_signal_ids ?? [])
     const latestSignal = signals[0] ?? null
+    const highPrioritySignals = signals.filter(
+      (signal) => signal.confidence >= mapFocusMinConfidence,
+    )
     const correlatedSignal =
-      signals.find((signal) => correlatedSignalIds.has(signal.id)) ?? null
-    const mapFocusSignal = correlatedSignal ?? latestSignal
+      highPrioritySignals.find((signal) => correlatedSignalIds.has(signal.id)) ??
+      null
+    const latestHighPrioritySignal = highPrioritySignals[0] ?? null
+    const mapFocusSignal = enableMapAutoFocus
+      ? correlatedSignal ?? latestHighPrioritySignal
+      : null
     const attributionState = stateFromUiEvent(latestUiEvent)
 
     return {
@@ -145,5 +161,5 @@ export function useCanopyMissionState(
       latestSignal,
       latestUiEvent,
     }
-  }, [signals, uiEvents])
+  }, [enableMapAutoFocus, mapFocusMinConfidence, signals, uiEvents])
 }

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,17 @@
   --cyan: #33f2f0;
   --olive: #a7b96f;
   --violet: #8b87c7;
+  --status-white: var(--white);
+  --status-amber: var(--amber);
+  --status-red: var(--red);
+  --status-live: var(--green);
+  --status-live-bright: #a7d5ad;
+  --domain-rf-ew: #b8841f;
+  --domain-cyber: var(--violet);
+  --domain-pnt: #7fa8d8;
+  --domain-space: #65b8b2;
+  --domain-drone: var(--green);
+  --domain-context: #9ba6ad;
   --panel: rgba(13, 23, 24, 0.9);
   --panel-strong: rgba(9, 17, 18, 0.96);
   --panel-soft: rgba(24, 38, 38, 0.76);

--- a/src/pages/Brigade.tsx
+++ b/src/pages/Brigade.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ApproveBanner } from '../components/ApproveBanner'
 import { EventFeed } from '../components/EventFeed'
 import { MapStage } from '../components/MapStage'
@@ -19,6 +19,11 @@ type MockSignalInput = Omit<
   payload: Record<string, unknown>
 }
 
+type DemoSignalTemplate = Omit<MockSignalInput, 'id' | 'ts' | 'confidence'> & {
+  confidence: [number, number]
+  cadence?: 'normal' | 'surge'
+}
+
 const makeBeatSignal = (signal: MockSignalInput): Signal => ({
   ...signal,
   realism: 'mock_operational',
@@ -33,6 +38,17 @@ const makeBeatSignal = (signal: MockSignalInput): Signal => ({
     method: 'ui_fallback',
   },
 })
+
+const randomBetween = ([min, max]: [number, number]) =>
+  min + Math.random() * (max - min)
+
+const demoConfidenceForSequence = (sequence: number) =>
+  sequence % 5 === 0 ? randomBetween([0.86, 0.96]) : randomBetween([0.74, 0.85])
+
+const randomDemoDelay = () => 1000 + Math.floor(Math.random() * 4000)
+
+const jitter = (value: number, amount: number) =>
+  Number((value + (Math.random() - 0.5) * amount).toFixed(5))
 
 const beatSignals: Signal[] = [
   makeBeatSignal({
@@ -91,6 +107,233 @@ const beatSignals: Signal[] = [
   }),
 ]
 
+const demoSignalTemplates: DemoSignalTemplate[] = [
+  {
+    domain: 'rf_ew',
+    source: 'brigade-spectrum-team',
+    location: {
+      lat: 34.63,
+      lng: 36.55,
+      alt_m: 310,
+      label: 'Forward UAS operating box',
+    },
+    payload: {
+      beat: 'frontend_tail_demo',
+      event_type: 'rf_interference',
+      asset: 'UAS-LINK-GROUP-B',
+      summary: 'EW team detects rising interference against drone C2 links.',
+      observables: {
+        center_freq_mhz: 1782.1,
+        bandwidth_mhz: 4.8,
+        bearing_deg: 82,
+        affected_assets: ['DRONE-04', 'DRONE-05', 'DRONE-08'],
+      },
+    },
+    confidence: [0.81, 0.91],
+    cadence: 'surge',
+  },
+  {
+    domain: 'pnt',
+    source: 'gnss-integrity-monitor',
+    location: {
+      lat: 34.66,
+      lng: 36.58,
+      alt_m: 285,
+      label: 'Forward UAS operating box',
+    },
+    payload: {
+      beat: 'frontend_tail_demo',
+      event_type: 'gps_spoof',
+      asset: 'UAS-LINK-GROUP-B',
+      summary: 'Drones report coherent GPS displacement inconsistent with inertial estimates.',
+      observables: {
+        affected_assets: ['DRONE-04', 'DRONE-05', 'DRONE-08'],
+        delta_meters: 420,
+        shared_bias_vector: true,
+      },
+    },
+    confidence: [0.86, 0.95],
+    cadence: 'surge',
+  },
+  {
+    domain: 'drone',
+    source: 'uas-swarm-controller',
+    location: {
+      lat: 34.67,
+      lng: 36.6,
+      alt_m: 300,
+      label: 'Forward UAS operating box',
+    },
+    payload: {
+      beat: 'frontend_tail_demo',
+      event_type: 'autonomous_relay_handoff',
+      asset: 'DRONE-08',
+      summary: 'Drone swarm shifts relay path away from spoofed nodes.',
+      observables: {
+        previous_primary: 'DRONE-04',
+        new_primary: 'DRONE-08',
+        handoff_success: true,
+        new_nav_mode: 'inertial_visual_odometry',
+      },
+    },
+    confidence: [0.88, 0.96],
+  },
+  {
+    domain: 'cyber',
+    source: 'brigade-siem',
+    location: {
+      lat: 34.51,
+      lng: 36.41,
+      alt_m: 240,
+      label: 'Brigade tactical operations node',
+    },
+    payload: {
+      beat: 'frontend_tail_demo',
+      event_type: 'credential_probe',
+      asset: 'BDE-C2-GATEWAY',
+      summary: 'Credential probes target the gateway forwarding drone telemetry.',
+      observables: {
+        failed_logins_60s: 63,
+        target_service: 'telemetry-forwarder',
+        overlaps_rf_window: true,
+      },
+    },
+    confidence: [0.72, 0.86],
+  },
+  {
+    domain: 'satcom',
+    source: 'brigade-satcom-controller',
+    location: {
+      lat: 34.5,
+      lng: 36.4,
+      alt_m: 250,
+      label: 'Brigade tactical operations node',
+    },
+    payload: {
+      beat: 'frontend_tail_demo',
+      event_type: 'satcom_degradation',
+      asset: 'BDE-SATCOM-1',
+      summary: 'SATCOM link degrades while relay and PNT anomalies are active.',
+      observables: {
+        packet_loss_pct: 12.7,
+        jitter_ms: 71,
+        link_margin_db: 0.7,
+        fallback_route: 'DRONE-08-MESH',
+      },
+    },
+    confidence: [0.78, 0.89],
+  },
+  {
+    domain: 'osint',
+    source: 'canopy-correlation-engine',
+    location: {
+      lat: 34.6,
+      lng: 36.52,
+      label: 'Brigade operating area',
+    },
+    payload: {
+      beat: 'frontend_tail_demo',
+      event_type: 'multi_domain_attack_assessment',
+      asset: 'CANOPY-MISSION-CELL',
+      summary: 'CANOPY assesses coordinated counter-C5ISR pressure against ISR, PNT, SATCOM, and space support.',
+      observables: {
+        assessment: 'coordinated_counter_c5isr_pressure',
+        recommended_response: 'preserve relay, reduce emissions, request space support options',
+      },
+    },
+    confidence: [0.84, 0.92],
+  },
+  {
+    domain: 'sda',
+    source: 'leo-custody-track',
+    location: {
+      lat: 34.8,
+      lng: 36.8,
+      alt_km: 548,
+      label: 'LEO custody arc',
+    },
+    payload: {
+      beat: 'frontend_tail_demo',
+      event_type: 'rpo_close_approach',
+      asset: 'RSO-8841',
+      summary: 'LEO custody track enters close-approach watch box near SATCOM support window.',
+      observables: {
+        range_km: 146,
+        relative_velocity_mps: 42,
+        watch_box: 'SATCOM-SUPPORT-WINDOW',
+      },
+    },
+    confidence: [0.8, 0.93],
+  },
+  {
+    domain: 'terrain',
+    source: 'cached-aor-terrain',
+    location: {
+      area_wkt:
+        'POLYGON((36.18 34.25,36.34 34.25,36.34 34.39,36.18 34.39,36.18 34.25))',
+      label: 'Northern relay corridor',
+    },
+    payload: {
+      beat: 'frontend_tail_demo',
+      event_type: 'terrain_masking_risk',
+      asset: 'RELAY-CORRIDOR-NORTH',
+      summary: 'Terrain model indicates relay is near a line-of-sight masking zone.',
+      observables: {
+        masking_ridge_m: 612,
+        affected_links: ['DRONE-02->FOXTROT-OBS-2'],
+        alternate_relay_candidate: 'DRONE-06',
+      },
+    },
+    confidence: [0.74, 0.84],
+  },
+]
+
+const makeDemoSignal = (sequence: number): Signal => {
+  const surgeWindow = sequence % 18 >= 7 && sequence % 18 <= 12
+  const surgeTemplates = demoSignalTemplates.filter(
+    (template) => template.cadence === 'surge',
+  )
+  const sourceTemplates = surgeWindow ? surgeTemplates : demoSignalTemplates
+  const template =
+    sourceTemplates[Math.floor(Math.random() * sourceTemplates.length)] ??
+    demoSignalTemplates[0]
+  const ts = new Date().toISOString()
+  const confidence = Number(demoConfidenceForSequence(sequence).toFixed(2))
+  const observables =
+    typeof template.payload.observables === 'object' &&
+    template.payload.observables !== null
+      ? template.payload.observables
+      : {}
+  const location = {
+    ...template.location,
+    lat:
+      typeof template.location?.lat === 'number'
+        ? jitter(template.location.lat, 0.08)
+        : template.location?.lat,
+    lng:
+      typeof template.location?.lng === 'number'
+        ? jitter(template.location.lng, 0.08)
+        : template.location?.lng,
+  }
+
+  return makeBeatSignal({
+    ...template,
+    id: `demo-tail-${sequence.toString().padStart(4, '0')}`,
+    ts,
+    confidence,
+    location,
+    payload: {
+      ...template.payload,
+      observables: {
+        ...observables,
+        priority_band: confidence >= 0.86 ? 'critical' : 'amber',
+        stream_sequence: sequence,
+        surge_window: surgeWindow,
+      },
+    },
+  })
+}
+
 const beatAttribution: Attribution = {
   id: 'att-ghost-lance',
   ts: nowMinus(1),
@@ -127,7 +370,19 @@ const beatDecision: Decision = {
 
 export function Brigade() {
   const socketState = useCanopySocket()
+  const forceDemoStream = new URLSearchParams(window.location.search).has(
+    'demoStream',
+  )
   const [beatIndex, setBeatIndex] = useState(1)
+  const [demoStream, setDemoStream] = useState<Signal[]>(() =>
+    beatSignals.map((signal, index) => ({
+      ...signal,
+      id: `demo-tail-${index.toString().padStart(4, '0')}`,
+      ts: nowMinus((beatSignals.length - index) * 2),
+    })),
+  )
+  const demoSequenceRef = useRef(beatSignals.length)
+  const [isMapAutoFocusEnabled, setIsMapAutoFocusEnabled] = useState(false)
   const [isApproved, setIsApproved] = useState(false)
 
   useEffect(() => {
@@ -138,25 +393,45 @@ export function Brigade() {
     return () => window.clearInterval(timer)
   }, [])
 
-  const mockSignals = useMemo(
-    () =>
-      beatSignals
-        .slice(0, beatIndex)
-        .map((signal, index) => ({
-          ...signal,
-          ts: nowMinus((beatIndex - index) * 4),
-        }))
-        .reverse(),
-    [beatIndex],
-  )
+  useEffect(() => {
+    if (socketState.isConnected && !forceDemoStream) {
+      return
+    }
 
-  const signals = socketState.signals.length ? socketState.signals : mockSignals
+    let timer: number
+
+    const scheduleNextSignal = () => {
+      timer = window.setTimeout(() => {
+        demoSequenceRef.current += 1
+        const nextSignal = makeDemoSignal(demoSequenceRef.current)
+        setDemoStream((current) => [nextSignal, ...current].slice(0, 50))
+        scheduleNextSignal()
+      }, randomDemoDelay())
+    }
+
+    scheduleNextSignal()
+
+    return () => window.clearTimeout(timer)
+  }, [forceDemoStream, socketState.isConnected])
+
+  const isUsingLiveSignals = !forceDemoStream && socketState.signals.length > 0
+  const signals = isUsingLiveSignals ? socketState.signals : demoStream
+  const dataModeLabel = isUsingLiveSignals
+    ? 'Live data'
+    : forceDemoStream
+      ? 'Demo stream'
+      : socketState.isConnected
+        ? 'Socket idle'
+        : 'Demo data'
   const latestAttribution =
     socketState.attributions[0] ?? (beatIndex >= 4 ? beatAttribution : null)
   const latestDecision =
     socketState.decisions[0] ?? (beatIndex >= 5 ? beatDecision : null)
   const latestUiEvent = socketState.uiEvents[0] ?? null
-  const missionState = useCanopyMissionState(signals, socketState.uiEvents)
+  const missionState = useCanopyMissionState(signals, socketState.uiEvents, {
+    enableMapAutoFocus: isMapAutoFocusEnabled,
+    mapFocusMinConfidence: 0.86,
+  })
 
   return (
     <main className="brigade-shell">
@@ -168,12 +443,12 @@ export function Brigade() {
         <div className="app-header__right">
           <span
             className={
-              socketState.isConnected
+              isUsingLiveSignals
                 ? 'socket-status socket-status--online'
                 : 'socket-status'
             }
           >
-            {socketState.isConnected ? 'Live data' : 'Demo data'}
+            {dataModeLabel}
           </span>
           <a href="/operator">Ops</a>
         </div>
@@ -189,7 +464,14 @@ export function Brigade() {
             signals={signals}
           />
 
-          <EventFeed signals={signals} />
+          <EventFeed
+            isLive={isUsingLiveSignals}
+            isMapAutoFocusEnabled={isMapAutoFocusEnabled}
+            onToggleMapAutoFocus={() =>
+              setIsMapAutoFocusEnabled((isEnabled) => !isEnabled)
+            }
+            signals={signals}
+          />
         </section>
 
         <aside className="decision-stack" aria-label="Commander decision stack">


### PR DESCRIPTION
Added a raw signals panel, switchable on the main central panel. Panel shows raw data, status. Also added dummy inputs to simulate the inflow of data. Input data flows in once ever 1-5 seconds, randomized. New data priority is at a 80% amber 20% critical split. New toggleable button on the central panel that toggles focus on critical developments. This feature can be turned off, preventing the user from jumping from one event to another.