### PR TITLE
Enable TypeScript strict mode

### DIFF
--- a/src/components/EventFeed.tsx
+++ b/src/components/EventFeed.tsx
@@ -333,12 +333,15 @@ export function EventFeed({
     return () => window.clearInterval(timer)
   }, [flowFrames.length, latestSignalId])
 
-  const feedState =
-    latestSignal?.confidence >= 0.86
+  const feedState = latestSignal ? priorityForSignal(latestSignal) : 'idle'
+  const feedStateLabel =
+    feedState === 'high'
       ? 'PRIORITY'
-      : latestSignal?.confidence >= 0.74
+      : feedState === 'watch'
         ? 'WATCH'
-        : 'MONITOR'
+        : feedState === 'low'
+          ? 'MONITOR'
+          : 'IDLE'
   const flowFrame =
     flowFrames[
       Math.min(
@@ -357,7 +360,7 @@ export function EventFeed({
         : 'scenario'
       : activeView === 'flow'
         ? 'flow'
-        : feedState.toLowerCase()
+        : feedState
   const statusLabel =
     activeView === 'raw'
       ? isLive
@@ -365,7 +368,7 @@ export function EventFeed({
         : 'FEED'
       : activeView === 'flow'
         ? 'FLOW'
-        : feedState
+        : feedStateLabel
   const flowShapeClass = (node: FlowNodeId, shapeClass: string) =>
     [
       'event-flow__shape',

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "strict": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "types": ["node"],
     "skipLibCheck": true,
+    "strict": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Enables TypeScript strict mode for both app and node compiler configs. Updates EventFeed status derivation to avoid optional-chain numeric comparison against undefined and to provide an explicit idle state. Verified with npm run build and npm run lint.