### PR TITLE
ci: add CI workflow and Vitest tests for the frontend store + hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python · pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      # uv reads .python-version (3.12) and installs the dev dependency-group
+      # (pytest, pytest-asyncio) automatically on first `uv run`.
+      - name: Run pytest
+        run: uv run pytest
+
+  frontend:
+    name: Frontend · lint · typecheck · test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Typecheck (app)
+        run: npm run typecheck
+      - name: Typecheck (tests)
+        run: npm run typecheck:test
+      - name: Unit tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -25,11 +28,71 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
+        "jsdom": "^29.1.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.10",
-        "vite-plugin-static-copy": "^4.1.0"
+        "vite-plugin-static-copy": "^4.1.0",
+        "vitest": "^4.1.7"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -223,6 +286,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -269,6 +342,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@cesium/engine": {
@@ -320,6 +406,146 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -482,6 +708,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1008,6 +1252,88 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
@@ -1024,6 +1350,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1366,6 +1717,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.26",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
@@ -1417,6 +1881,29 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1442,6 +1929,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autolinker": {
@@ -1477,6 +1984,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -1597,6 +2114,16 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1663,12 +2190,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1688,12 +2250,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1704,6 +2283,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -1732,6 +2318,26 @@
       "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1928,6 +2534,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1936,6 +2552,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2121,6 +2747,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2139,6 +2778,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -2187,6 +2836,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2200,6 +2856,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsep": {
       "version": "1.4.0",
@@ -2598,6 +3305,26 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/maplibre-gl": {
       "version": "5.24.0",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
@@ -2632,6 +3359,13 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/mersenne-twister": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
@@ -2649,6 +3383,16 @@
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-2.1.0.tgz",
       "integrity": "sha512-/pjuM02PUAhp4dazfccTSKBGTGPFkRz9LKwGJKusc/B20apcGG/CYnRHx0kXmLXy4m5O3p6y6nOVxEnErPpFvQ==",
       "license": "MIT"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -2737,6 +3481,17 @@
       "integrity": "sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==",
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2806,6 +3561,19 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2825,6 +3593,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pbf": {
       "version": "4.0.1",
@@ -2903,6 +3678,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
@@ -2969,6 +3759,13 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2993,6 +3790,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-protobuf-schema": {
@@ -3051,6 +3872,19 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3090,6 +3924,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3100,6 +3941,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
@@ -3107,6 +3975,30 @@
       "license": "ISC",
       "dependencies": {
         "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.3.tgz",
+      "integrity": "sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -3131,6 +4023,36 @@
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -3157,6 +4079,32 @@
         "topo2geo": "bin/topo2geo",
         "topomerge": "bin/topomerge",
         "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3227,6 +4175,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3383,6 +4341,144 @@
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3399,6 +4495,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3408,6 +4521,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc -b",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "cesium": "^1.141.0",
@@ -19,6 +23,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -27,9 +34,11 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
+    "jsdom": "^29.1.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.10",
-    "vite-plugin-static-copy": "^4.1.0"
+    "vite-plugin-static-copy": "^4.1.0",
+    "vitest": "^4.1.7"
   }
 }

--- a/src/hooks/useCanopyMissionState.test.ts
+++ b/src/hooks/useCanopyMissionState.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useCanopyMissionState } from './useCanopyMissionState'
+import {
+  makeSignal as buildSignal,
+  makeUIEvent as buildUIEvent,
+} from '../test/factories'
+import type { Signal, UISeverity, UIEvent } from '../types/canopy'
+
+// ---------------------------------------------------------------------------
+// Auto-id wrappers over the shared factories. This suite never cares about a
+// signal/event's specific id — only that each is unique (correlation tests
+// read `.id` back) — so ids come from a per-file counter. The shared makeSignal
+// defaults payload.event_type to the domain, which keeps commanderLanguage's
+// `detail` output stable.
+// ---------------------------------------------------------------------------
+
+let signalSeq = 0
+let eventSeq = 0
+
+const makeSignal = (overrides: Partial<Signal> = {}): Signal =>
+  buildSignal(`sig-${++signalSeq}`, overrides)
+
+const makeUiEvent = (overrides: Partial<UIEvent> = {}): UIEvent =>
+  buildUIEvent(`evt-${++eventSeq}`, overrides)
+
+// Convenience: render the hook and return result.current.
+type Options = Parameters<typeof useCanopyMissionState>[2]
+const run = (signals: Signal[], uiEvents: UIEvent[], options?: Options) =>
+  renderHook(() => useCanopyMissionState(signals, uiEvents, options)).result
+    .current
+
+describe('useCanopyMissionState — threatState / attribution.state from latest UI event severity', () => {
+  const severityCases: Array<[UISeverity, 'white' | 'amber' | 'red']> = [
+    ['critical', 'red'],
+    ['high', 'red'],
+    ['medium', 'amber'],
+    ['low', 'white'],
+  ]
+
+  for (const [severity, expected] of severityCases) {
+    it(`maps severity '${severity}' -> threatState '${expected}'`, () => {
+      const state = run([], [makeUiEvent({ severity })])
+      expect(state.threatState).toBe(expected)
+      expect(state.statuses.attribution.state).toBe(expected)
+    })
+  }
+
+  it("defaults threatState to 'white' when there is no UI event", () => {
+    const state = run([makeSignal()], [])
+    expect(state.threatState).toBe('white')
+    expect(state.statuses.attribution.state).toBe('white')
+  })
+
+  it('uses only the FIRST (latest) UI event severity, ignoring older ones', () => {
+    const latest = makeUiEvent({ severity: 'medium' })
+    const older = makeUiEvent({ severity: 'critical' })
+    const state = run([], [latest, older])
+    // amber from the latest, not red from the older critical event.
+    expect(state.threatState).toBe('amber')
+  })
+})
+
+describe('useCanopyMissionState — domain bucketing (spaceLayer vs blosComms)', () => {
+  it('spaceLayer aggregates only orbit/sda signals', () => {
+    const orbit = makeSignal({ domain: 'orbit', confidence: 0.9 })
+    const sda = makeSignal({ domain: 'sda', confidence: 0.8 })
+    // A comms-domain signal must not leak into spaceLayer.
+    const satcom = makeSignal({ domain: 'satcom', confidence: 0.95 })
+    const state = run([orbit, sda, satcom], [])
+    // 2 space signals, highest confidence 0.9 -> red.
+    expect(state.statuses.spaceLayer.metric).toBe('90% / 2 live')
+    expect(state.statuses.spaceLayer.state).toBe('red')
+  })
+
+  it('blosComms aggregates only satcom/rf_ew/cyber/pnt/drone signals', () => {
+    const satcom = makeSignal({ domain: 'satcom', confidence: 0.75 })
+    const rfEw = makeSignal({ domain: 'rf_ew', confidence: 0.6 })
+    const cyber = makeSignal({ domain: 'cyber', confidence: 0.5 })
+    const pnt = makeSignal({ domain: 'pnt', confidence: 0.5 })
+    const drone = makeSignal({ domain: 'drone', confidence: 0.5 })
+    // A space signal must not leak into blosComms.
+    const orbit = makeSignal({ domain: 'orbit', confidence: 0.99 })
+    const state = run([satcom, rfEw, cyber, pnt, drone, orbit], [])
+    // 5 comms signals, highest 0.75 -> amber.
+    expect(state.statuses.blosComms.metric).toBe('75% / 5 live')
+    expect(state.statuses.blosComms.state).toBe('amber')
+  })
+
+  it("an unrelated domain (osint) influences neither bucket's confidence-derived state", () => {
+    const osint = makeSignal({ domain: 'osint', confidence: 0.99 })
+    const state = run([osint], [])
+    // osint is in neither set -> both buckets stay empty.
+    expect(state.statuses.spaceLayer.state).toBe('white')
+    expect(state.statuses.spaceLayer.metric).toBe('No live hits')
+    expect(state.statuses.blosComms.state).toBe('white')
+    expect(state.statuses.blosComms.metric).toBe('No live hits')
+  })
+
+  it("humint and terrain are also outside both buckets", () => {
+    const humint = makeSignal({ domain: 'humint', confidence: 0.95 })
+    const terrain = makeSignal({ domain: 'terrain', confidence: 0.95 })
+    const state = run([humint, terrain], [])
+    expect(state.statuses.spaceLayer.metric).toBe('No live hits')
+    expect(state.statuses.blosComms.metric).toBe('No live hits')
+  })
+})
+
+describe('useCanopyMissionState — confidence -> state thresholds (via a bucket)', () => {
+  it('confidence >= 0.86 -> red', () => {
+    const state = run([makeSignal({ domain: 'orbit', confidence: 0.86 })], [])
+    expect(state.statuses.spaceLayer.state).toBe('red')
+  })
+
+  it('confidence in [0.72, 0.86) -> amber (lower bound)', () => {
+    const state = run([makeSignal({ domain: 'orbit', confidence: 0.72 })], [])
+    expect(state.statuses.spaceLayer.state).toBe('amber')
+  })
+
+  it('confidence in [0.72, 0.86) -> amber (just below the red cutoff)', () => {
+    const state = run([makeSignal({ domain: 'orbit', confidence: 0.8599 })], [])
+    expect(state.statuses.spaceLayer.state).toBe('amber')
+  })
+
+  it('confidence < 0.72 -> white', () => {
+    const state = run([makeSignal({ domain: 'orbit', confidence: 0.7199 })], [])
+    expect(state.statuses.spaceLayer.state).toBe('white')
+  })
+
+  it("empty bucket -> metric 'No live hits' and state 'white'", () => {
+    const state = run([], [])
+    expect(state.statuses.spaceLayer.metric).toBe('No live hits')
+    expect(state.statuses.spaceLayer.state).toBe('white')
+    expect(state.statuses.blosComms.metric).toBe('No live hits')
+    expect(state.statuses.blosComms.state).toBe('white')
+  })
+
+  it('uses the HIGHEST confidence in the bucket to derive state, not the latest', () => {
+    // latest (first) is low, but a later high-confidence signal drives state red.
+    const lowLatest = makeSignal({ domain: 'orbit', confidence: 0.3 })
+    const highOlder = makeSignal({ domain: 'sda', confidence: 0.91 })
+    const state = run([lowLatest, highOlder], [])
+    expect(state.statuses.spaceLayer.state).toBe('red')
+    // metric pct comes from the highest (91%), count is both signals.
+    expect(state.statuses.spaceLayer.metric).toBe('91% / 2 live')
+  })
+})
+
+describe('useCanopyMissionState — correlation bump (strongerState)', () => {
+  it('a correlated in-bucket signal lifts a white bucket to at least amber', () => {
+    // Confidence alone (0.3) would be white.
+    const sig = makeSignal({ domain: 'orbit', confidence: 0.3 })
+    const event = makeUiEvent({
+      severity: 'low',
+      source_signal_ids: [sig.id],
+    })
+    const state = run([sig], [event])
+    expect(state.statuses.spaceLayer.state).toBe('amber')
+  })
+
+  it('correlation does NOT downgrade an already-red bucket', () => {
+    const sig = makeSignal({ domain: 'orbit', confidence: 0.95 })
+    const event = makeUiEvent({ source_signal_ids: [sig.id] })
+    const state = run([sig], [event])
+    // red (rank 2) is stronger than amber (rank 1) -> stays red.
+    expect(state.statuses.spaceLayer.state).toBe('red')
+  })
+
+  it('correlation against a signal in the OTHER bucket does not bump this bucket', () => {
+    const orbit = makeSignal({ domain: 'orbit', confidence: 0.3 })
+    const satcom = makeSignal({ domain: 'satcom', confidence: 0.3 })
+    // Correlate only the satcom (blosComms) signal.
+    const event = makeUiEvent({ source_signal_ids: [satcom.id] })
+    const state = run([orbit, satcom], [event])
+    expect(state.statuses.spaceLayer.state).toBe('white') // not correlated
+    expect(state.statuses.blosComms.state).toBe('amber') // correlated bump
+  })
+
+  it('correlation ids that match no in-bucket signal leave the bucket white', () => {
+    const sig = makeSignal({ domain: 'orbit', confidence: 0.3 })
+    const event = makeUiEvent({ source_signal_ids: ['does-not-exist'] })
+    const state = run([sig], [event])
+    expect(state.statuses.spaceLayer.state).toBe('white')
+  })
+})
+
+describe('useCanopyMissionState — metric string format', () => {
+  it('formats as "<roundedPct>% / <count> live" with rounding of highest confidence', () => {
+    // 0.736 * 100 = 73.6 -> rounds to 74.
+    const a = makeSignal({ domain: 'satcom', confidence: 0.736 })
+    const b = makeSignal({ domain: 'rf_ew', confidence: 0.5 })
+    const state = run([a, b], [])
+    expect(state.statuses.blosComms.metric).toBe('74% / 2 live')
+  })
+
+  it('rounds half up at the .5 boundary', () => {
+    // 0.725 * 100 = 72.5 -> Math.round -> 73.
+    const state = run([makeSignal({ domain: 'orbit', confidence: 0.725 })], [])
+    expect(state.statuses.spaceLayer.metric).toBe('73% / 1 live')
+  })
+
+  it('count reflects only in-bucket signals', () => {
+    const state = run(
+      [
+        makeSignal({ domain: 'orbit', confidence: 0.4 }),
+        makeSignal({ domain: 'sda', confidence: 0.9 }),
+        makeSignal({ domain: 'satcom', confidence: 0.9 }), // other bucket
+        makeSignal({ domain: 'osint', confidence: 0.9 }), // no bucket
+      ],
+      [],
+    )
+    expect(state.statuses.spaceLayer.metric).toBe('90% / 2 live')
+  })
+})
+
+describe('useCanopyMissionState — correlatedSignalIds', () => {
+  it("equals the latest UI event's source_signal_ids as an array", () => {
+    const event = makeUiEvent({ source_signal_ids: ['a', 'b', 'c'] })
+    const state = run([], [event])
+    expect(state.correlatedSignalIds).toEqual(['a', 'b', 'c'])
+    expect(Array.isArray(state.correlatedSignalIds)).toBe(true)
+  })
+
+  it('comes from the latest (first) event only', () => {
+    const latest = makeUiEvent({ source_signal_ids: ['x'] })
+    const older = makeUiEvent({ source_signal_ids: ['y', 'z'] })
+    const state = run([], [latest, older])
+    expect(state.correlatedSignalIds).toEqual(['x'])
+  })
+
+  it('is empty when there is no UI event', () => {
+    const state = run([makeSignal()], [])
+    expect(state.correlatedSignalIds).toEqual([])
+  })
+
+  it('de-duplicates ids (built from a Set)', () => {
+    const event = makeUiEvent({ source_signal_ids: ['dup', 'dup', 'unique'] })
+    const state = run([], [event])
+    expect(state.correlatedSignalIds).toEqual(['dup', 'unique'])
+  })
+})
+
+describe('useCanopyMissionState — latestSignal / latestUiEvent', () => {
+  it('returns the first element of each input array', () => {
+    const first = makeSignal({ domain: 'orbit' })
+    const second = makeSignal({ domain: 'sda' })
+    const firstEvent = makeUiEvent({ title: 'first' })
+    const secondEvent = makeUiEvent({ title: 'second' })
+    const state = run([first, second], [firstEvent, secondEvent])
+    expect(state.latestSignal).toBe(first)
+    expect(state.latestUiEvent).toBe(firstEvent)
+  })
+
+  it('returns null when the corresponding array is empty', () => {
+    const state = run([], [])
+    expect(state.latestSignal).toBeNull()
+    expect(state.latestUiEvent).toBeNull()
+  })
+
+  it('latestSignal is independent of domain bucketing', () => {
+    // osint is in no bucket but is still the latest signal.
+    const osint = makeSignal({ domain: 'osint' })
+    const state = run([osint], [])
+    expect(state.latestSignal).toBe(osint)
+  })
+})
+
+describe('useCanopyMissionState — mapFocusSignalId', () => {
+  it('prefers a correlated high-confidence signal over the latest high-confidence one', () => {
+    const latestHigh = makeSignal({ domain: 'orbit', confidence: 0.9 })
+    const correlatedHigh = makeSignal({ domain: 'sda', confidence: 0.88 })
+    const event = makeUiEvent({ source_signal_ids: [correlatedHigh.id] })
+    const state = run([latestHigh, correlatedHigh], [event])
+    expect(state.mapFocusSignalId).toBe(correlatedHigh.id)
+  })
+
+  it('falls back to the latest signal with confidence >= 0.86 when none is correlated', () => {
+    const lowFirst = makeSignal({ domain: 'orbit', confidence: 0.5 })
+    const highSecond = makeSignal({ domain: 'sda', confidence: 0.9 })
+    const evenHigherThird = makeSignal({ domain: 'satcom', confidence: 0.95 })
+    // No correlation -> picks the FIRST signal that clears the threshold.
+    const state = run([lowFirst, highSecond, evenHigherThird], [])
+    expect(state.mapFocusSignalId).toBe(highSecond.id)
+  })
+
+  it('returns null when no signal meets the default 0.86 threshold', () => {
+    const state = run(
+      [
+        makeSignal({ domain: 'orbit', confidence: 0.85 }),
+        makeSignal({ domain: 'satcom', confidence: 0.7 }),
+      ],
+      [],
+    )
+    expect(state.mapFocusSignalId).toBeNull()
+  })
+
+  it('includes a signal exactly at the 0.86 threshold', () => {
+    const sig = makeSignal({ domain: 'orbit', confidence: 0.86 })
+    const state = run([sig], [])
+    expect(state.mapFocusSignalId).toBe(sig.id)
+  })
+
+  it('a correlated but LOW-confidence signal does not qualify; falls back to latest high', () => {
+    const correlatedLow = makeSignal({ domain: 'orbit', confidence: 0.5 })
+    const latestHigh = makeSignal({ domain: 'sda', confidence: 0.9 })
+    const event = makeUiEvent({ source_signal_ids: [correlatedLow.id] })
+    // correlatedLow is below threshold so it's not in highPrioritySignals;
+    // the high-confidence latest signal wins instead.
+    const state = run([latestHigh, correlatedLow], [event])
+    expect(state.mapFocusSignalId).toBe(latestHigh.id)
+  })
+
+  it('is always null when enableMapAutoFocus is false, even with a strong correlated signal', () => {
+    const sig = makeSignal({ domain: 'orbit', confidence: 0.99 })
+    const event = makeUiEvent({ source_signal_ids: [sig.id] })
+    const state = run([sig], [event], { enableMapAutoFocus: false })
+    expect(state.mapFocusSignalId).toBeNull()
+  })
+
+  it('honors a custom mapFocusMinConfidence (0.5 lets a 0.6 signal qualify)', () => {
+    const sig = makeSignal({ domain: 'orbit', confidence: 0.6 })
+    const state = run([sig], [], { mapFocusMinConfidence: 0.5 })
+    expect(state.mapFocusSignalId).toBe(sig.id)
+  })
+
+  it('with the default threshold a 0.6 signal does NOT qualify', () => {
+    const sig = makeSignal({ domain: 'orbit', confidence: 0.6 })
+    const state = run([sig], [])
+    expect(state.mapFocusSignalId).toBeNull()
+  })
+})
+
+describe('useCanopyMissionState — attribution status', () => {
+  it("derives label from latestUiEvent.type with underscores -> spaces", () => {
+    const event = makeUiEvent({ type: 'recommendation_created' })
+    const state = run([], [event])
+    expect(state.statuses.attribution.label).toBe('recommendation created')
+  })
+
+  it("label is 'Building picture' when there is no event", () => {
+    const state = run([makeSignal()], [])
+    expect(state.statuses.attribution.label).toBe('Building picture')
+  })
+
+  it('handles other event types (threat_updated, status_update)', () => {
+    expect(
+      run([], [makeUiEvent({ type: 'threat_updated' })]).statuses.attribution
+        .label,
+    ).toBe('threat updated')
+    expect(
+      run([], [makeUiEvent({ type: 'status_update' })]).statuses.attribution
+        .label,
+    ).toBe('status update')
+  })
+
+  it('metric reflects event confidence; detail reflects event title', () => {
+    const event = makeUiEvent({
+      confidence: 0.823,
+      title: 'Convergence forming over the support window',
+    })
+    const state = run([], [event])
+    // 0.823 * 100 = 82.3 -> 82.
+    expect(state.statuses.attribution.metric).toBe('82% confidence')
+    expect(state.statuses.attribution.detail).toBe(
+      'Convergence forming over the support window',
+    )
+  })
+
+  it("metric is 'No call yet' and detail is the empty placeholder without an event", () => {
+    const state = run([makeSignal()], [])
+    expect(state.statuses.attribution.metric).toBe('No call yet')
+    expect(state.statuses.attribution.detail).toBe(
+      'No commander-facing assessment yet.',
+    )
+  })
+
+  it('attribution title is the fixed string', () => {
+    const state = run([], [makeUiEvent()])
+    expect(state.statuses.attribution.title).toBe('Assessment')
+  })
+})
+
+describe('useCanopyMissionState — static titles/labels and detail wiring', () => {
+  it('exposes the fixed titles and labels for the space and comms buckets', () => {
+    const state = run([], [])
+    expect(state.statuses.spaceLayer.title).toBe('Space Support')
+    expect(state.statuses.spaceLayer.label).toBe('Satellites / Overhead')
+    expect(state.statuses.blosComms.title).toBe('Comms and Navigation')
+    expect(state.statuses.blosComms.label).toBe('SATCOM / GPS / Drones')
+  })
+
+  it('uses the per-bucket empty-detail copy when no in-bucket signal exists', () => {
+    const state = run([], [])
+    expect(state.statuses.spaceLayer.detail).toBe(
+      'No space-support change has arrived.',
+    )
+    expect(state.statuses.blosComms.detail).toBe(
+      'No communications or navigation degradation has arrived.',
+    )
+  })
+
+  it('bucket detail derives from commanderSignalSummary of the latest in-bucket signal (non-empty)', () => {
+    // event_type === domain -> plainEventName returns `${label} report`.
+    const orbit = makeSignal({ domain: 'orbit', confidence: 0.4 })
+    const state = run([orbit], [])
+    expect(state.statuses.spaceLayer.detail).toBe('Satellite proximity report')
+    expect(state.statuses.spaceLayer.detail.length).toBeGreaterThan(0)
+  })
+
+  it('bucket detail uses the FIRST in-bucket signal even if a later one has higher confidence', () => {
+    // First space signal is orbit, second is sda with higher confidence.
+    const orbit = makeSignal({ domain: 'orbit', confidence: 0.3 })
+    const sda = makeSignal({ domain: 'sda', confidence: 0.95 })
+    const state = run([orbit, sda], [])
+    // detail follows the latest (first) in-bucket signal -> orbit's label.
+    expect(state.statuses.spaceLayer.detail).toBe('Satellite proximity report')
+  })
+
+  it('bucket detail is a stable non-empty string for an event_type that hits the override table', () => {
+    const sig = makeSignal({
+      domain: 'satcom',
+      confidence: 0.5,
+      payload: {
+        event_type: 'satcom_degradation',
+        summary: 'SATCOM link quality is degrading on the primary path.',
+      },
+    })
+    const state = run([sig], [])
+    expect(typeof state.statuses.blosComms.detail).toBe('string')
+    expect(state.statuses.blosComms.detail.length).toBeGreaterThan(0)
+  })
+})
+
+describe('useCanopyMissionState — combined / integration behaviour', () => {
+  it('threat is white but both buckets red when only confidence is high and no event exists', () => {
+    const state = run(
+      [
+        makeSignal({ domain: 'orbit', confidence: 0.9 }),
+        makeSignal({ domain: 'satcom', confidence: 0.9 }),
+      ],
+      [],
+    )
+    expect(state.threatState).toBe('white')
+    expect(state.statuses.spaceLayer.state).toBe('red')
+    expect(state.statuses.blosComms.state).toBe('red')
+  })
+
+  it('returns a memoized object that is stable across re-renders with identical inputs', () => {
+    const signals = [makeSignal({ domain: 'orbit', confidence: 0.9 })]
+    const uiEvents = [makeUiEvent({ severity: 'high' })]
+    const { result, rerender } = renderHook(
+      ({ s, e }: { s: Signal[]; e: UIEvent[] }) =>
+        useCanopyMissionState(s, e),
+      { initialProps: { s: signals, e: uiEvents } },
+    )
+    const first = result.current
+    rerender({ s: signals, e: uiEvents })
+    // useMemo deps are referentially identical -> same object reference.
+    expect(result.current).toBe(first)
+  })
+
+  it('recomputes when the signals array reference changes', () => {
+    const { result, rerender } = renderHook(
+      ({ s }: { s: Signal[] }) => useCanopyMissionState(s, []),
+      { initialProps: { s: [makeSignal({ domain: 'orbit', confidence: 0.4 })] } },
+    )
+    const first = result.current
+    rerender({ s: [makeSignal({ domain: 'orbit', confidence: 0.9 })] })
+    expect(result.current).not.toBe(first)
+    expect(result.current.statuses.spaceLayer.state).toBe('red')
+  })
+})

--- a/src/hooks/useCanopySocket.test.ts
+++ b/src/hooks/useCanopySocket.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCanopySocket } from './useCanopySocket'
+import { useEventStore } from '../store/eventStore'
+import { MockWebSocket } from '../test/mockWebSocket'
+import {
+  makeAnomaly,
+  makeAttribution,
+  makeDecision,
+  makeEmbeddingSnapshot,
+  makeSignal,
+  makeTrace,
+  makeUIEvent,
+} from '../test/factories'
+import type { Signal } from '../types/canopy'
+
+const TEST_URL = 'ws://test/ws'
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+  // Isolate the global Zustand store: reset() restores initial state and
+  // clearing sessionStorage stops the persist middleware from rehydrating
+  // a previous test's buffers into this one.
+  useEventStore.getState().reset()
+  sessionStorage.clear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useCanopySocket', () => {
+  it('opens a socket against the supplied url with the expected initial state', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.last?.url).toBe(TEST_URL)
+
+    expect(result.current.isConnected).toBe(false)
+    expect(result.current.lastError).toBeNull()
+    expect(result.current.signals).toEqual([])
+    expect(result.current.anomalies).toEqual([])
+    expect(result.current.attributions).toEqual([])
+    expect(result.current.decisions).toEqual([])
+    expect(result.current.uiEvents).toEqual([])
+    expect(result.current.traces).toEqual([])
+  })
+
+  it('does not construct a WebSocket when url is null', () => {
+    const { result } = renderHook(() => useCanopySocket(null))
+
+    expect(MockWebSocket.instances).toHaveLength(0)
+    // State stays at the untouched initial snapshot.
+    expect(result.current.isConnected).toBe(false)
+    expect(result.current.lastError).toBeNull()
+    expect(result.current.signals).toEqual([])
+  })
+
+  it('marks isConnected true and clears lastError on open', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+
+    // Seed an error first so we can prove open clears it.
+    act(() => MockWebSocket.last!.emitError())
+    expect(result.current.lastError).toBe('CANOPY socket error')
+
+    act(() => MockWebSocket.last!.emitOpen())
+    expect(result.current.isConnected).toBe(true)
+    expect(result.current.lastError).toBeNull()
+  })
+
+  it('marks isConnected false on close', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+
+    act(() => MockWebSocket.last!.emitOpen())
+    expect(result.current.isConnected).toBe(true)
+
+    act(() => MockWebSocket.last!.emitClose())
+    expect(result.current.isConnected).toBe(false)
+  })
+
+  it('sets lastError on error without touching isConnected', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+
+    act(() => MockWebSocket.last!.emitOpen())
+    expect(result.current.isConnected).toBe(true)
+
+    act(() => MockWebSocket.last!.emitError())
+    expect(result.current.lastError).toBe('CANOPY socket error')
+    // Error alone does not flip the connection flag.
+    expect(result.current.isConnected).toBe(true)
+  })
+
+  it('ingests a kind:signal envelope into local state and the global store', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const signal = makeSignal('sig-1')
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ kind: 'signal', data: signal }),
+    )
+
+    expect(result.current.signals).toEqual([signal])
+
+    const store = useEventStore.getState()
+    expect(store.signals).toEqual([signal])
+    expect(store.signalsById['sig-1']).toEqual(signal)
+  })
+
+  it('ingests an anomaly envelope into local state and the global store', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const anomaly = makeAnomaly('anom-1')
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ kind: 'anomaly', data: anomaly }),
+    )
+
+    expect(result.current.anomalies).toEqual([anomaly])
+    expect(useEventStore.getState().anomalies).toEqual([anomaly])
+  })
+
+  it('ingests an attribution envelope into local state and the global store', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const attribution = makeAttribution('attr-1')
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({
+        kind: 'attribution',
+        data: attribution,
+      }),
+    )
+
+    expect(result.current.attributions).toEqual([attribution])
+
+    const store = useEventStore.getState()
+    expect(store.attributions).toEqual([attribution])
+    expect(store.attributionsById['attr-1']).toEqual(attribution)
+  })
+
+  it('ingests a decision envelope into local state and the global store', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const decision = makeDecision('dec-1')
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ kind: 'decision', data: decision }),
+    )
+
+    expect(result.current.decisions).toEqual([decision])
+
+    const store = useEventStore.getState()
+    expect(store.decisions).toEqual([decision])
+    expect(store.decisionsById['dec-1']).toEqual(decision)
+  })
+
+  it('ingests a ui_event envelope into local state and the global store', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const uiEvent = makeUIEvent('ui-1')
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ kind: 'ui_event', data: uiEvent }),
+    )
+
+    expect(result.current.uiEvents).toEqual([uiEvent])
+    expect(useEventStore.getState().uiEvents).toEqual([uiEvent])
+  })
+
+  it('ingests a trace envelope into local state and the global store', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const trace = makeTrace('trace-1')
+
+    act(() => MockWebSocket.last!.emitMessage({ kind: 'trace', data: trace }))
+
+    expect(result.current.traces).toEqual([trace])
+    expect(useEventStore.getState().traces).toEqual([trace])
+  })
+
+  it('routes an embedding envelope to the store snapshot without changing local arrays', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const snapshot = makeEmbeddingSnapshot('emb-1')
+
+    const before = result.current
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ kind: 'embedding', data: snapshot }),
+    )
+
+    // Store receives the snapshot wholesale...
+    expect(useEventStore.getState().embeddingSnapshot).toEqual(snapshot)
+
+    // ...but no CanopySocketState array is mutated.
+    expect(result.current.signals).toEqual([])
+    expect(result.current.anomalies).toEqual([])
+    expect(result.current.attributions).toEqual([])
+    expect(result.current.decisions).toEqual([])
+    expect(result.current.uiEvents).toEqual([])
+    expect(result.current.traces).toEqual([])
+    // reduceMessage returns the same state object for embeddings.
+    expect(result.current).toBe(before)
+  })
+
+  it('accepts the legacy {type:...} envelope identically to {kind:...}', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const signal = makeSignal('legacy-1')
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ type: 'signal', data: signal }),
+    )
+
+    expect(result.current.signals).toEqual([signal])
+    expect(useEventStore.getState().signalsById['legacy-1']).toEqual(signal)
+  })
+
+  it('prefers the string `type` discriminator when both type and kind are present', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const signal = makeSignal('both-1')
+
+    // normalizeMessage checks `type` first; with type:'signal' this must be
+    // routed as a signal regardless of the bogus `kind`.
+    act(() =>
+      MockWebSocket.last!.emitMessage({
+        type: 'signal',
+        kind: 'anomaly',
+        data: signal,
+      }),
+    )
+
+    expect(result.current.signals).toEqual([signal])
+    expect(result.current.anomalies).toEqual([])
+  })
+
+  it('ignores an envelope with an unknown discriminator', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const before = result.current
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({
+        kind: 'bogus',
+        data: { id: 'x' },
+      }),
+    )
+
+    // No throw, no state change, no error recorded.
+    expect(result.current).toBe(before)
+    expect(result.current.lastError).toBeNull()
+    expect(useEventStore.getState().signals).toEqual([])
+  })
+
+  it('ignores an envelope whose data is not an object', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const before = result.current
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ kind: 'signal', data: 'not-an-object' }),
+    )
+
+    expect(result.current).toBe(before)
+    expect(result.current.signals).toEqual([])
+    expect(result.current.lastError).toBeNull()
+  })
+
+  it('ignores an envelope whose data is null', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const before = result.current
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ kind: 'signal', data: null }),
+    )
+
+    expect(result.current).toBe(before)
+    expect(result.current.signals).toEqual([])
+    expect(result.current.lastError).toBeNull()
+  })
+
+  it('ignores an envelope missing both type and kind', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+    const before = result.current
+
+    act(() =>
+      MockWebSocket.last!.emitMessage({ data: makeSignal('orphan') }),
+    )
+
+    expect(result.current).toBe(before)
+    expect(result.current.signals).toEqual([])
+    expect(result.current.lastError).toBeNull()
+  })
+
+  it('records lastError on invalid JSON without throwing', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+
+    act(() => MockWebSocket.last!.emitMessage('not json'))
+
+    expect(result.current.lastError).toBe('Invalid CANOPY socket payload')
+    // Buffers untouched by the parse failure.
+    expect(result.current.signals).toEqual([])
+    expect(useEventStore.getState().signals).toEqual([])
+  })
+
+  it('dedups signals by id and moves the repeat to the front (prependLimited)', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+
+    const a = makeSignal('A')
+    const b = makeSignal('B')
+    const aUpdated: Signal = { ...makeSignal('A'), confidence: 0.42 }
+
+    act(() => MockWebSocket.last!.emitMessage({ kind: 'signal', data: a }))
+    act(() => MockWebSocket.last!.emitMessage({ kind: 'signal', data: b }))
+    // Re-send id 'A' with new contents: dedup to a single entry, moved front.
+    act(() =>
+      MockWebSocket.last!.emitMessage({ kind: 'signal', data: aUpdated }),
+    )
+
+    expect(result.current.signals).toHaveLength(2)
+    expect(result.current.signals.map((s) => s.id)).toEqual(['A', 'B'])
+    // The kept 'A' is the latest version.
+    expect(result.current.signals[0]).toEqual(aUpdated)
+    expect(result.current.signals[0].confidence).toBe(0.42)
+  })
+
+  it('caps local signals at 50, newest first, after 55 distinct arrivals', () => {
+    const { result } = renderHook(() => useCanopySocket(TEST_URL))
+
+    for (let i = 0; i < 55; i++) {
+      const sig = makeSignal(`sig-${i}`)
+      act(() => MockWebSocket.last!.emitMessage({ kind: 'signal', data: sig }))
+    }
+
+    const signals = result.current.signals
+    expect(signals).toHaveLength(50)
+    // Newest first: the last id sent (54) is at the head.
+    expect(signals[0].id).toBe('sig-54')
+    // The oldest survivor is id 5 (0..4 fell off the 50-item window).
+    expect(signals[49].id).toBe('sig-5')
+    expect(signals.map((s) => s.id)).not.toContain('sig-4')
+    expect(signals.map((s) => s.id)).not.toContain('sig-0')
+  })
+
+  it('closes the socket on unmount', () => {
+    const { unmount } = renderHook(() => useCanopySocket(TEST_URL))
+
+    const socket = MockWebSocket.last!
+    expect(socket.closed).toBe(false)
+
+    unmount()
+
+    expect(socket.closed).toBe(true)
+  })
+})

--- a/src/hooks/useEngineSocket.test.ts
+++ b/src/hooks/useEngineSocket.test.ts
@@ -1,0 +1,513 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useEngineSocket,
+  triggerReplay,
+  listScenarios,
+} from './useEngineSocket'
+import { useEventStore } from '../store/eventStore'
+import { MockWebSocket } from '../test/mockWebSocket'
+import {
+  makeAnomaly,
+  makeAttribution,
+  makeDecision,
+  makeKBEntry,
+  makeSignal,
+  makeTrace,
+  makeUIEvent,
+} from '../test/factories'
+import type { UIEvent, WSEnvelope } from '../types/canopy'
+
+// ---------------------------------------------------------------------------
+// Test-specific fixtures (the shared factories live in ../test/factories).
+// ---------------------------------------------------------------------------
+const KB_ENTRY = makeKBEntry('kb-actor-001', {
+  actor: 'Red Forces',
+  title: 'Co-orbital interceptor doctrine',
+  summary: 'Synthetic KB entry for tests.',
+})
+
+// A fixture UIEvent whose source_signal_ids match an entry in the hook's
+// FIXTURE_SIGNAL_LOCATIONS table, so fixture mode synthesises a marker signal.
+const FIXTURE_EVENT: UIEvent = makeUIEvent('fixture-evt-1', {
+  source_signal_ids: ['canopy-beat1-001'],
+  type: 'threat_updated',
+  title: 'Fixture replay event',
+  // Deliberately stale timestamp — the hook must overwrite it with a fresh one.
+  timestamp: '2000-01-01T00:00:00.000Z',
+  ts: '2000-01-01T00:00:00.000Z',
+})
+
+// ---------------------------------------------------------------------------
+// Fetch mock routed by URL.
+// ---------------------------------------------------------------------------
+
+// Minimal fetch Response stand-in carrying a JSON body.
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: () => Promise.resolve(body) } as unknown as Response
+}
+
+function makeFetchMock() {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.endsWith('/kb')) {
+      return Promise.resolve(jsonResponse({ entries: [KB_ENTRY] }))
+    }
+    if (url.includes('/fixture/ui_events')) {
+      return Promise.resolve(jsonResponse({ events: [FIXTURE_EVENT] }))
+    }
+    if (url.includes('/scenarios')) {
+      return Promise.resolve(jsonResponse(['beat1']))
+    }
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+let fetchMock: ReturnType<typeof makeFetchMock>
+
+beforeEach(() => {
+  fetchMock = makeFetchMock()
+  vi.stubGlobal('fetch', fetchMock)
+  vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+  MockWebSocket.instances = []
+  useEventStore.getState().reset()
+  sessionStorage.clear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+const store = () => useEventStore.getState()
+
+describe('useEngineSocket — mount + KB load', () => {
+  it('fetches /kb on mount and keys the store kb by entry id', async () => {
+    renderHook(() => useEngineSocket())
+
+    // The KB fetch fires synchronously in the effect; flush its promise chain.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/kb')
+    expect(store().kb).toEqual({ [KB_ENTRY.id]: KB_ENTRY })
+    expect(store().kb[KB_ENTRY.id].title).toBe(KB_ENTRY.title)
+  })
+
+  it('opens a WebSocket to the derived ws:// URL on mount', () => {
+    renderHook(() => useEngineSocket())
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.last?.url).toBe('ws://localhost:8000/ws')
+  })
+
+  it('does not crash if the /kb fetch rejects', async () => {
+    fetchMock.mockImplementationOnce(() => Promise.reject(new Error('boom')))
+
+    renderHook(() => useEngineSocket())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // KB stays empty; the socket is still established.
+    expect(store().kb).toEqual({})
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+})
+
+describe('useEngineSocket — connection lifecycle', () => {
+  it('sets connecting on mount then live once the socket opens', () => {
+    renderHook(() => useEngineSocket())
+
+    // connect() runs synchronously and sets "connecting".
+    expect(store().connection).toBe('connecting')
+
+    act(() => {
+      MockWebSocket.last?.emitOpen()
+    })
+    expect(store().connection).toBe('live')
+  })
+
+  it('an error on the socket closes it (so reconnect logic can run)', () => {
+    renderHook(() => useEngineSocket())
+    const sock = MockWebSocket.last
+    expect(sock?.closed).toBe(false)
+
+    act(() => {
+      sock?.emitError()
+    })
+    expect(sock?.closed).toBe(true)
+  })
+})
+
+describe('useEngineSocket — message handling per WSEnvelope.kind', () => {
+  it('ingests each envelope kind into the matching store buffer', () => {
+    renderHook(() => useEngineSocket())
+    const sock = MockWebSocket.last
+    act(() => sock?.emitOpen())
+
+    const envelopes: WSEnvelope[] = [
+      { topic: 'signal', kind: 'signal', data: makeSignal('sig-1') },
+      { topic: 'anomaly', kind: 'anomaly', data: makeAnomaly('an-1') },
+      {
+        topic: 'attribution',
+        kind: 'attribution',
+        data: makeAttribution('at-1'),
+      },
+      { topic: 'decision', kind: 'decision', data: makeDecision('dec-1') },
+      { topic: 'ui_event', kind: 'ui_event', data: makeUIEvent('uie-1') },
+      { topic: 'trace', kind: 'trace', data: makeTrace('tr-1') },
+    ]
+
+    act(() => {
+      for (const env of envelopes) sock?.emitMessage(env)
+    })
+
+    const s = store()
+    expect(s.signals).toHaveLength(1)
+    expect(s.signals[0].id).toBe('sig-1')
+    expect(s.signalsById['sig-1']).toBeDefined()
+
+    expect(s.anomalies).toHaveLength(1)
+    expect(s.anomalies[0].id).toBe('an-1')
+
+    expect(s.attributions).toHaveLength(1)
+    expect(s.attributionsById['at-1']).toBeDefined()
+
+    expect(s.decisions).toHaveLength(1)
+    expect(s.decisionsById['dec-1']).toBeDefined()
+
+    expect(s.uiEvents).toHaveLength(1)
+    expect(s.uiEvents[0].id).toBe('uie-1')
+
+    expect(s.traces).toHaveLength(1)
+    expect(s.traces[0].id).toBe('tr-1')
+  })
+
+  it('pops the approval banner for a recommendation_created ui_event', () => {
+    renderHook(() => useEngineSocket())
+    const sock = MockWebSocket.last
+    act(() => sock?.emitOpen())
+
+    const recEvent = makeUIEvent('rec-1', {
+      type: 'recommendation_created',
+      recommendation: {
+        id: 'r-1',
+        summary: 'Recommend escort burn',
+        approveLabel: 'Approve',
+      },
+    })
+    const envelope: WSEnvelope = {
+      topic: 'ui_event',
+      kind: 'ui_event',
+      data: recEvent,
+    }
+
+    act(() => sock?.emitMessage(envelope))
+
+    expect(store().pendingApproval?.id).toBe('rec-1')
+  })
+
+  it('does not throw on a malformed (non-JSON) message and keeps working', () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {})
+    renderHook(() => useEngineSocket())
+    const sock = MockWebSocket.last
+    act(() => sock?.emitOpen())
+
+    expect(() =>
+      act(() => {
+        sock?.emitMessage('not json')
+      }),
+    ).not.toThrow()
+
+    // It logged the parse failure and ingested nothing.
+    expect(consoleErr).toHaveBeenCalled()
+    expect(store().signals).toHaveLength(0)
+    expect(store().uiEvents).toHaveLength(0)
+
+    // A subsequent valid message is still handled — the socket isn't poisoned.
+    const env: WSEnvelope = {
+      topic: 'signal',
+      kind: 'signal',
+      data: makeSignal('sig-after'),
+    }
+    act(() => sock?.emitMessage(env))
+    expect(store().signals).toHaveLength(1)
+    expect(store().signals[0].id).toBe('sig-after')
+
+    consoleErr.mockRestore()
+  })
+})
+
+describe('useEngineSocket — reconnect backoff + fixture fallback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('reconnects with [500, 1500, 4000] backoffs then falls back to fixture mode on the 4th failure', async () => {
+    renderHook(() => useEngineSocket())
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    const backoffs = [500, 1500, 4000]
+    for (let cycle = 0; cycle < backoffs.length; cycle++) {
+      const sockCount = MockWebSocket.instances.length
+      // Close the current socket → schedules a reconnect.
+      act(() => {
+        MockWebSocket.last?.emitClose()
+      })
+      // While the timer is pending the hook reports "connecting".
+      expect(store().connection).toBe('connecting')
+      // No new socket yet — must wait the backoff.
+      expect(MockWebSocket.instances).toHaveLength(sockCount)
+
+      // Advancing just under the delay still produces no new socket.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(backoffs[cycle] - 1)
+      })
+      expect(MockWebSocket.instances).toHaveLength(sockCount)
+
+      // Crossing the delay constructs exactly one new socket.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1)
+      })
+      expect(MockWebSocket.instances).toHaveLength(sockCount + 1)
+    }
+
+    // 1 initial + 3 reconnects.
+    expect(MockWebSocket.instances).toHaveLength(4)
+    expect(store().connection).toBe('connecting')
+
+    // The FOURTH consecutive failure (failures >= 3) triggers fixture mode.
+    await act(async () => {
+      MockWebSocket.last?.emitClose()
+      // Flush the fixture fetch promise chain.
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(store().connection).toBe('fixture')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8000/fixture/ui_events',
+    )
+    // No further socket was constructed by entering fixture mode.
+    expect(MockWebSocket.instances).toHaveLength(4)
+  })
+
+  it('resets the failure counter when a reconnect opens successfully', async () => {
+    renderHook(() => useEngineSocket())
+
+    // Two failures (uses [500, 1500]).
+    act(() => MockWebSocket.last?.emitClose())
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    act(() => MockWebSocket.last?.emitClose())
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500)
+    })
+    expect(MockWebSocket.instances).toHaveLength(3)
+
+    // This reconnect opens — counter resets to 0.
+    act(() => MockWebSocket.last?.emitOpen())
+    expect(store().connection).toBe('live')
+
+    // The very next close starts the backoff sequence again at 500ms.
+    act(() => MockWebSocket.last?.emitClose())
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499)
+    })
+    expect(MockWebSocket.instances).toHaveLength(3)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(MockWebSocket.instances).toHaveLength(4)
+    // Still reconnecting (would need 3 more failures to fall back), not fixture.
+    expect(store().connection).toBe('connecting')
+  })
+})
+
+describe('useEngineSocket — fixture replay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  // Drives the hook into fixture mode via 4 consecutive socket failures.
+  async function enterFixtureMode() {
+    for (const delay of [500, 1500, 4000]) {
+      act(() => MockWebSocket.last?.emitClose())
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(delay)
+      })
+    }
+    await act(async () => {
+      MockWebSocket.last?.emitClose()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+  }
+
+  it('replays fixture UIEvents on the 3000ms interval with fresh ISO timestamps', async () => {
+    renderHook(() => useEngineSocket())
+    await enterFixtureMode()
+    expect(store().connection).toBe('fixture')
+
+    // The first tick fires immediately once the fixture file resolves.
+    expect(store().uiEvents).toHaveLength(1)
+    const first = store().uiEvents[0]
+    expect(first.id).toBe(FIXTURE_EVENT.id)
+    // Timestamp was synthesised fresh — a valid ISO string, NOT the stale one.
+    expect(first.timestamp).not.toBe(FIXTURE_EVENT.timestamp)
+    expect(Number.isNaN(Date.parse(first.timestamp))).toBe(false)
+    expect(new Date(first.timestamp).toISOString()).toBe(first.timestamp)
+
+    // The fixture event references a known signal id → a marker signal appears.
+    expect(store().signals).toHaveLength(1)
+    expect(store().signals[0].id).toBe('canopy-beat1-001')
+    expect(store().signals[0].source).toBe('fixture')
+
+    // Each FIXTURE_REPLAY_INTERVAL_MS advance replays another event.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    expect(store().uiEvents).toHaveLength(2)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    expect(store().uiEvents).toHaveLength(3)
+  })
+
+  it('goes offline if the fixture file fetch rejects', async () => {
+    // Make only the fixture fetch reject; /kb and the initial calls still work.
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/fixture/ui_events')) {
+        return Promise.reject(new Error('no fixture'))
+      }
+      if (url.endsWith('/kb')) {
+        return Promise.resolve(jsonResponse({ entries: [KB_ENTRY] }))
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
+
+    renderHook(() => useEngineSocket())
+    await enterFixtureMode()
+
+    expect(store().connection).toBe('offline')
+    expect(store().uiEvents).toHaveLength(0)
+  })
+})
+
+describe('useEngineSocket — cleanup on unmount', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('closes the active socket and stops reconnect timers', async () => {
+    const { unmount } = renderHook(() => useEngineSocket())
+    const sock = MockWebSocket.last
+    expect(sock?.closed).toBe(false)
+
+    // Schedule a reconnect, then unmount before it fires.
+    act(() => sock?.emitClose())
+    unmount()
+
+    expect(sock?.closed).toBe(true)
+
+    // Advancing past every backoff must NOT create another socket.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000)
+    })
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('stops the fixture replay timer on unmount (no further ingests)', async () => {
+    const { unmount } = renderHook(() => useEngineSocket())
+
+    // Enter fixture mode.
+    for (const delay of [500, 1500, 4000]) {
+      act(() => MockWebSocket.last?.emitClose())
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(delay)
+      })
+    }
+    await act(async () => {
+      MockWebSocket.last?.emitClose()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(store().connection).toBe('fixture')
+    const eventsBefore = store().uiEvents.length
+    expect(eventsBefore).toBeGreaterThan(0)
+    const socketsBefore = MockWebSocket.instances.length
+
+    unmount()
+
+    // Time passing after unmount replays nothing and builds no new sockets.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+    })
+    expect(store().uiEvents).toHaveLength(eventsBefore)
+    expect(MockWebSocket.instances).toHaveLength(socketsBefore)
+  })
+})
+
+describe('triggerReplay', () => {
+  it('POSTs to /scenarios/<name>/replay with the given speed', async () => {
+    await triggerReplay('beatX', 7)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit?,
+    ]
+    expect(String(url)).toBe(
+      'http://localhost:8000/scenarios/beatX/replay?speed=7',
+    )
+    expect(init?.method).toBe('POST')
+  })
+
+  it('defaults speed to 5 when omitted', async () => {
+    await triggerReplay('beat1')
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'http://localhost:8000/scenarios/beat1/replay?speed=5',
+    )
+  })
+
+  it('URL-encodes the scenario name', async () => {
+    await triggerReplay('beat 1/special', 3)
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'http://localhost:8000/scenarios/beat%201%2Fspecial/replay?speed=3',
+    )
+  })
+})
+
+describe('listScenarios', () => {
+  it('returns the parsed array when the response is ok', async () => {
+    const result = await listScenarios()
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/scenarios')
+    expect(result).toEqual(['beat1'])
+  })
+
+  it('returns [] when the response is not ok', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(['should-not-be-used'], false))
+
+    expect(await listScenarios()).toEqual([])
+  })
+
+  it('returns [] when the fetch rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+
+    expect(await listScenarios()).toEqual([])
+  })
+})

--- a/src/store/eventStore.test.ts
+++ b/src/store/eventStore.test.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import { useEventStore } from './eventStore'
+import {
+  makeAnomaly,
+  makeAttribution,
+  makeDecision,
+  makeEmbeddingSnapshot,
+  makeKBEntry,
+  makeManeuverDemo,
+  makeRecommendationEvent,
+  makeSignal,
+  makeTrace,
+  makeUIEvent,
+} from '../test/factories'
+import type {
+  ConnectionStatus,
+  OsintEmbeddingSnapshot,
+  ReasoningTrace,
+  Signal,
+  ViewMode,
+} from '../types/canopy'
+
+const STORAGE_KEY = 'canopy-event-store'
+
+// Convenience accessor that always reads the current store snapshot.
+const store = () => useEventStore.getState()
+
+beforeEach(() => {
+  useEventStore.getState().reset()
+  sessionStorage.clear()
+})
+
+describe('eventStore — ingestSignal', () => {
+  it('prepends newest-first and indexes by id', () => {
+    store().ingestSignal(makeSignal('a'))
+    store().ingestSignal(makeSignal('b'))
+
+    const { signals, signalsById } = store()
+    expect(signals.map((s) => s.id)).toEqual(['b', 'a'])
+    expect(signalsById['a']?.id).toBe('a')
+    expect(signalsById['b']?.id).toBe('b')
+    // Lookup map returns the same object instance that was ingested.
+    expect(signalsById['b']).toBe(signals[0])
+  })
+
+  it('caps the ring buffer at 200 keeping the newest at index 0', () => {
+    for (let i = 0; i < 205; i++) {
+      store().ingestSignal(makeSignal(`s${i}`))
+    }
+
+    const { signals, signalsById } = store()
+    expect(signals).toHaveLength(200)
+    // Newest (last pushed) sits at the front.
+    expect(signals[0]?.id).toBe('s204')
+    // Oldest surviving is the 6th item we pushed (s0..s4 fell off).
+    expect(signals[199]?.id).toBe('s5')
+    expect(signals.find((s) => s.id === 's4')).toBeUndefined()
+    // signalsById is not bounded — it accumulates every id seen.
+    expect(Object.keys(signalsById)).toHaveLength(205)
+    expect(signalsById['s0']?.id).toBe('s0')
+  })
+})
+
+describe('eventStore — ingestAnomaly', () => {
+  it('prepends newest-first', () => {
+    store().ingestAnomaly(makeAnomaly('x'))
+    store().ingestAnomaly(makeAnomaly('y'))
+    expect(store().anomalies.map((a) => a.id)).toEqual(['y', 'x'])
+  })
+
+  it('respects the 200-item ring buffer', () => {
+    for (let i = 0; i < 205; i++) store().ingestAnomaly(makeAnomaly(`a${i}`))
+    const { anomalies } = store()
+    expect(anomalies).toHaveLength(200)
+    expect(anomalies[0]?.id).toBe('a204')
+    expect(anomalies[199]?.id).toBe('a5')
+  })
+})
+
+describe('eventStore — ingestAttribution', () => {
+  it('prepends newest-first and populates attributionsById', () => {
+    store().ingestAttribution(makeAttribution('p'))
+    store().ingestAttribution(makeAttribution('q'))
+
+    const { attributions, attributionsById } = store()
+    expect(attributions.map((a) => a.id)).toEqual(['q', 'p'])
+    expect(attributionsById['p']?.id).toBe('p')
+    expect(attributionsById['q']).toBe(attributions[0])
+  })
+
+  it('respects the 200-item ring buffer', () => {
+    for (let i = 0; i < 205; i++) store().ingestAttribution(makeAttribution(`at${i}`))
+    expect(store().attributions).toHaveLength(200)
+    expect(store().attributions[0]?.id).toBe('at204')
+  })
+})
+
+describe('eventStore — ingestDecision', () => {
+  it('prepends newest-first and populates decisionsById', () => {
+    store().ingestDecision(makeDecision('d1'))
+    store().ingestDecision(makeDecision('d2'))
+
+    const { decisions, decisionsById } = store()
+    expect(decisions.map((d) => d.id)).toEqual(['d2', 'd1'])
+    expect(decisionsById['d1']?.id).toBe('d1')
+    expect(decisionsById['d2']).toBe(decisions[0])
+  })
+
+  it('respects the 200-item ring buffer', () => {
+    for (let i = 0; i < 205; i++) store().ingestDecision(makeDecision(`dec${i}`))
+    expect(store().decisions).toHaveLength(200)
+    expect(store().decisions[0]?.id).toBe('dec204')
+  })
+})
+
+describe('eventStore — ingestUIEvent', () => {
+  it('sets pendingApproval for a recommendation_created event with a recommendation', () => {
+    const evt = makeRecommendationEvent('rec1')
+    store().ingestUIEvent(evt)
+
+    expect(store().uiEvents[0]?.id).toBe('rec1')
+    expect(store().pendingApproval).toBe(evt)
+  })
+
+  it('does NOT set pendingApproval when the event id is already approved', () => {
+    store().markApproved('rec1')
+    const evt = makeRecommendationEvent('rec1')
+    store().ingestUIEvent(evt)
+
+    // The event still lands in the ring buffer...
+    expect(store().uiEvents[0]?.id).toBe('rec1')
+    // ...but the banner is suppressed because it was already approved.
+    expect(store().pendingApproval).toBeNull()
+  })
+
+  it('does NOT set pendingApproval for a recommendation_created event lacking a recommendation', () => {
+    const evt = makeUIEvent('rec-missing', {
+      type: 'recommendation_created',
+      recommendation: null,
+    })
+    store().ingestUIEvent(evt)
+
+    expect(store().uiEvents[0]?.id).toBe('rec-missing')
+    expect(store().pendingApproval).toBeNull()
+  })
+
+  it('never sets pendingApproval for a non-recommendation event', () => {
+    store().ingestUIEvent(makeUIEvent('threat1', { type: 'threat_updated' }))
+    expect(store().pendingApproval).toBeNull()
+
+    store().ingestUIEvent(makeUIEvent('status1', { type: 'status_update' }))
+    expect(store().pendingApproval).toBeNull()
+  })
+
+  it('prepends newest-first and respects the 200-item ring buffer', () => {
+    for (let i = 0; i < 205; i++) {
+      store().ingestUIEvent(makeUIEvent(`u${i}`))
+    }
+    const { uiEvents } = store()
+    expect(uiEvents).toHaveLength(200)
+    expect(uiEvents[0]?.id).toBe('u204')
+    expect(uiEvents[199]?.id).toBe('u5')
+  })
+
+  it('leaves an existing pendingApproval in place when a non-recommendation event arrives', () => {
+    const rec = makeRecommendationEvent('rec1')
+    store().ingestUIEvent(rec)
+    expect(store().pendingApproval).toBe(rec)
+
+    store().ingestUIEvent(makeUIEvent('threat1', { type: 'threat_updated' }))
+    // The banner persists — a plain threat update must not clobber it.
+    expect(store().pendingApproval).toBe(rec)
+  })
+})
+
+describe('eventStore — ingestTrace', () => {
+  it('appends oldest-first (newest at the end)', () => {
+    store().ingestTrace(makeTrace('t1'))
+    store().ingestTrace(makeTrace('t2'))
+    store().ingestTrace(makeTrace('t3'))
+
+    expect(store().traces.map((t) => t.id)).toEqual(['t1', 't2', 't3'])
+  })
+
+  it('caps at 500, dropping from the front', () => {
+    for (let i = 0; i < 505; i++) store().ingestTrace(makeTrace(`tr${i}`))
+
+    const { traces } = store()
+    expect(traces).toHaveLength(500)
+    // Front (oldest) items tr0..tr4 were dropped; tr5 is now the oldest.
+    expect(traces[0]?.id).toBe('tr5')
+    // Newest is at the end.
+    expect(traces[499]?.id).toBe('tr504')
+    expect(traces.find((t) => t.id === 'tr4')).toBeUndefined()
+  })
+})
+
+describe('eventStore — ingestEmbeddingSnapshot', () => {
+  it('replaces the snapshot wholesale (second write wins)', () => {
+    const first = makeEmbeddingSnapshot('snap1', { cluster_count: 1 })
+    const second = makeEmbeddingSnapshot('snap2', { cluster_count: 9 })
+
+    store().ingestEmbeddingSnapshot(first)
+    expect(store().embeddingSnapshot).toBe(first)
+
+    store().ingestEmbeddingSnapshot(second)
+    expect(store().embeddingSnapshot).toBe(second)
+    expect(store().embeddingSnapshot?.cluster_count).toBe(9)
+  })
+})
+
+describe('eventStore — markApproved', () => {
+  it('adds the id to approvedEventIds', () => {
+    store().markApproved('e1')
+    expect(store().approvedEventIds.has('e1')).toBe(true)
+    expect(store().approvedEventIds.size).toBe(1)
+  })
+
+  it('clears pendingApproval when it matches the approved id', () => {
+    const evt = makeRecommendationEvent('e1')
+    store().ingestUIEvent(evt)
+    expect(store().pendingApproval).toBe(evt)
+
+    store().markApproved('e1')
+    expect(store().pendingApproval).toBeNull()
+    expect(store().approvedEventIds.has('e1')).toBe(true)
+  })
+
+  it('leaves a non-matching pendingApproval intact', () => {
+    const evt = makeRecommendationEvent('e1')
+    store().ingestUIEvent(evt)
+
+    store().markApproved('other')
+    expect(store().pendingApproval).toBe(evt)
+    expect(store().approvedEventIds.has('other')).toBe(true)
+    expect(store().approvedEventIds.has('e1')).toBe(false)
+  })
+})
+
+describe('eventStore — acceptDecision / deferDecision are mutually exclusive', () => {
+  it('accepting an id removes it from deferred', () => {
+    store().deferDecision('d1')
+    expect(store().deferredDecisionIds.has('d1')).toBe(true)
+
+    store().acceptDecision('d1')
+    expect(store().acceptedDecisionIds.has('d1')).toBe(true)
+    expect(store().deferredDecisionIds.has('d1')).toBe(false)
+  })
+
+  it('deferring an id removes it from accepted', () => {
+    store().acceptDecision('d1')
+    expect(store().acceptedDecisionIds.has('d1')).toBe(true)
+
+    store().deferDecision('d1')
+    expect(store().deferredDecisionIds.has('d1')).toBe(true)
+    expect(store().acceptedDecisionIds.has('d1')).toBe(false)
+  })
+
+  it('tracks distinct ids independently across both sets', () => {
+    store().acceptDecision('accepted-1')
+    store().deferDecision('deferred-1')
+
+    expect(store().acceptedDecisionIds.has('accepted-1')).toBe(true)
+    expect(store().acceptedDecisionIds.has('deferred-1')).toBe(false)
+    expect(store().deferredDecisionIds.has('deferred-1')).toBe(true)
+    expect(store().deferredDecisionIds.has('accepted-1')).toBe(false)
+  })
+
+  it('clearDecisionStatus removes the id from both sets', () => {
+    store().acceptDecision('d1')
+    store().clearDecisionStatus('d1')
+    expect(store().acceptedDecisionIds.has('d1')).toBe(false)
+    expect(store().deferredDecisionIds.has('d1')).toBe(false)
+
+    store().deferDecision('d2')
+    store().clearDecisionStatus('d2')
+    expect(store().acceptedDecisionIds.has('d2')).toBe(false)
+    expect(store().deferredDecisionIds.has('d2')).toBe(false)
+  })
+
+  it('clearDecisionStatus is a no-op for an unknown id', () => {
+    store().acceptDecision('keep')
+    store().clearDecisionStatus('never-added')
+    expect(store().acceptedDecisionIds.has('keep')).toBe(true)
+  })
+})
+
+describe('eventStore — maneuver demo + takeover slots', () => {
+  it('startManeuverDemo / endManeuverDemo set and clear the slot', () => {
+    const demo = makeManeuverDemo({ decisionId: 'dec-42', demoType: 'strike' })
+    store().startManeuverDemo(demo)
+    expect(store().maneuverDemo).toBe(demo)
+    expect(store().maneuverDemo?.demoType).toBe('strike')
+
+    store().endManeuverDemo()
+    expect(store().maneuverDemo).toBeNull()
+  })
+
+  it('openTakeover / closeTakeover set and clear the slot', () => {
+    const evt = makeUIEvent('takeover-1')
+    store().openTakeover(evt)
+    expect(store().takeoverEvent).toBe(evt)
+
+    store().closeTakeover()
+    expect(store().takeoverEvent).toBeNull()
+  })
+})
+
+describe('eventStore — connection / view / selection / dismissal', () => {
+  it('setConnection updates the connection status', () => {
+    const statuses: ConnectionStatus[] = ['live', 'fixture', 'offline', 'connecting']
+    for (const status of statuses) {
+      store().setConnection(status)
+      expect(store().connection).toBe(status)
+    }
+  })
+
+  it('setView updates the view mode', () => {
+    const views: ViewMode[] = ['operator', 'brigade']
+    for (const view of views) {
+      store().setView(view)
+      expect(store().view).toBe(view)
+    }
+  })
+
+  it('selectEvent sets and clears the selected id', () => {
+    store().selectEvent('evt-1')
+    expect(store().selectedEventId).toBe('evt-1')
+    store().selectEvent(null)
+    expect(store().selectedEventId).toBeNull()
+  })
+
+  it('dismissApproval clears pendingApproval', () => {
+    const evt = makeRecommendationEvent('rec1')
+    store().ingestUIEvent(evt)
+    expect(store().pendingApproval).toBe(evt)
+
+    store().dismissApproval()
+    expect(store().pendingApproval).toBeNull()
+    // Dismissing does not record the id as approved.
+    expect(store().approvedEventIds.has('rec1')).toBe(false)
+  })
+})
+
+describe('eventStore — setKB', () => {
+  it('builds a record keyed by entry id', () => {
+    store().setKB([makeKBEntry('kb1'), makeKBEntry('kb2', { actor: 'BLUE' })])
+
+    const { kb } = store()
+    expect(Object.keys(kb).sort()).toEqual(['kb1', 'kb2'])
+    expect(kb['kb1']?.id).toBe('kb1')
+    expect(kb['kb2']?.actor).toBe('BLUE')
+  })
+
+  it('replaces the whole record on a subsequent call', () => {
+    store().setKB([makeKBEntry('kb1')])
+    store().setKB([makeKBEntry('kb3')])
+
+    const { kb } = store()
+    expect(Object.keys(kb)).toEqual(['kb3'])
+    expect(kb['kb1']).toBeUndefined()
+  })
+
+  it('handles an empty list', () => {
+    store().setKB([])
+    expect(store().kb).toEqual({})
+  })
+})
+
+describe('eventStore — reset', () => {
+  it('returns every field to its initial value with fresh empty Sets', () => {
+    // Mutate a broad cross-section of the store first.
+    store().ingestSignal(makeSignal('s'))
+    store().ingestAnomaly(makeAnomaly('a'))
+    store().ingestAttribution(makeAttribution('at'))
+    store().ingestDecision(makeDecision('d'))
+    store().ingestUIEvent(makeRecommendationEvent('rec'))
+    store().ingestTrace(makeTrace('t'))
+    store().ingestEmbeddingSnapshot(makeEmbeddingSnapshot('snap'))
+    store().setConnection('live')
+    store().setView('operator')
+    store().selectEvent('s')
+    store().markApproved('rec')
+    store().acceptDecision('d')
+    store().deferDecision('d2')
+    store().startManeuverDemo(makeManeuverDemo())
+    store().openTakeover(makeUIEvent('to'))
+    store().setKB([makeKBEntry('kb')])
+
+    store().reset()
+
+    const s = store()
+    expect(s.signals).toEqual([])
+    expect(s.anomalies).toEqual([])
+    expect(s.attributions).toEqual([])
+    expect(s.decisions).toEqual([])
+    expect(s.uiEvents).toEqual([])
+    expect(s.traces).toEqual([])
+    expect(s.embeddingSnapshot).toBeNull()
+    expect(s.signalsById).toEqual({})
+    expect(s.attributionsById).toEqual({})
+    expect(s.decisionsById).toEqual({})
+    expect(s.connection).toBe('connecting')
+    expect(s.view).toBe('brigade')
+    expect(s.selectedEventId).toBeNull()
+    expect(s.pendingApproval).toBeNull()
+    expect(s.maneuverDemo).toBeNull()
+    expect(s.takeoverEvent).toBeNull()
+    expect(s.kb).toEqual({})
+
+    // Fresh, genuinely-empty Set instances.
+    expect(s.approvedEventIds).toBeInstanceOf(Set)
+    expect(s.approvedEventIds.size).toBe(0)
+    expect(s.acceptedDecisionIds).toBeInstanceOf(Set)
+    expect(s.acceptedDecisionIds.size).toBe(0)
+    expect(s.deferredDecisionIds).toBeInstanceOf(Set)
+    expect(s.deferredDecisionIds.size).toBe(0)
+  })
+})
+
+describe('eventStore — persist partialize', () => {
+  it('persists ring buffers under the canopy-event-store key but excludes live/Set fields', async () => {
+    // Touch persisted (ring-buffer) state and live/Set state.
+    store().ingestSignal(makeSignal('s1'))
+    store().ingestTrace(makeTrace('t1'))
+    store().ingestEmbeddingSnapshot(makeEmbeddingSnapshot('snap1'))
+    store().setConnection('live')
+    store().setView('operator')
+    store().markApproved('approved-1')
+    store().acceptDecision('acc-1')
+    store().deferDecision('def-1')
+    store().startManeuverDemo(makeManeuverDemo())
+    store().openTakeover(makeUIEvent('to-1'))
+    store().setKB([makeKBEntry('kb1')])
+
+    // Persist writes may be flushed on a microtask — wait for the key.
+    await vi.waitFor(() => {
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull()
+    })
+
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw as string) as {
+      version: number
+      state: Record<string, unknown>
+    }
+    const persisted = parsed.state
+
+    // Included: ring buffers + lookup maps + embedding snapshot.
+    const includedKeys = [
+      'signals',
+      'anomalies',
+      'attributions',
+      'decisions',
+      'uiEvents',
+      'traces',
+      'embeddingSnapshot',
+      'signalsById',
+      'attributionsById',
+      'decisionsById',
+    ]
+    for (const key of includedKeys) {
+      expect(persisted).toHaveProperty(key)
+    }
+    expect((persisted.signals as Signal[])[0]?.id).toBe('s1')
+    expect((persisted.traces as ReasoningTrace[])[0]?.id).toBe('t1')
+    expect((persisted.embeddingSnapshot as OsintEmbeddingSnapshot)?.id).toBe('snap1')
+
+    // Excluded: live UI/connection state and Set-backed fields.
+    const excludedKeys = [
+      'connection',
+      'view',
+      'selectedEventId',
+      'approvedEventIds',
+      'acceptedDecisionIds',
+      'deferredDecisionIds',
+      'pendingApproval',
+      'maneuverDemo',
+      'takeoverEvent',
+      'kb',
+    ]
+    for (const key of excludedKeys) {
+      expect(persisted).not.toHaveProperty(key)
+    }
+
+    // The persisted blob carries exactly the partialized keys — nothing else.
+    expect(Object.keys(persisted).sort()).toEqual([...includedKeys].sort())
+    expect(parsed.version).toBe(2)
+  })
+})

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,0 +1,184 @@
+// Shared, fully-typed fixture factories for the frontend unit suites. Each
+// returns a complete object built on the project's canonical types with
+// sensible defaults that any field can override via a Partial.
+//
+// `id` is positional because most call sites care about a specific id (ring
+// buffers, lookup maps, correlation). Suites that want auto-generated ids wrap
+// these with a small local counter.
+import type {
+  Anomaly,
+  Attribution,
+  Decision,
+  Domain,
+  KBEntry,
+  OsintEmbeddingSnapshot,
+  ReasoningTrace,
+  Recommendation,
+  Signal,
+  UIEvent,
+} from '../types/canopy'
+import type { ManeuverDemo } from '../store/eventStore'
+
+const TS = '2026-05-30T00:00:00.000Z'
+
+export function makeSignal(id: string, overrides: Partial<Signal> = {}): Signal {
+  // event_type defaults to the domain so commanderLanguage resolves a stable
+  // `${domainLabel} report` detail string.
+  const domain: Domain = overrides.domain ?? 'orbit'
+  return {
+    id,
+    ts: TS,
+    domain,
+    source: 'test',
+    realism: 'mock_operational',
+    confidence: 0.5,
+    location: { label: 'LEO', lat: 0, lng: 0, alt_km: 550 },
+    payload: { event_type: domain, summary: `signal ${id}` },
+    provenance: { source_id: `src-${id}` },
+    ...overrides,
+  }
+}
+
+export function makeAnomaly(id: string, overrides: Partial<Anomaly> = {}): Anomaly {
+  return {
+    id,
+    ts: TS,
+    kind: 'maneuver',
+    source_signal: `sig-${id}`,
+    source_signal_ids: [`sig-${id}`],
+    severity: 3,
+    payload: {},
+    ...overrides,
+  }
+}
+
+export function makeAttribution(
+  id: string,
+  overrides: Partial<Attribution> = {},
+): Attribution {
+  return {
+    id,
+    ts: TS,
+    anomaly_ids: [`anom-${id}`],
+    actor: 'RED',
+    confidence: 0.75,
+    doctrine_match: null,
+    evidence: [],
+    predicted_next: null,
+    kb_citations: [],
+    source_signal_ids: [],
+    ...overrides,
+  }
+}
+
+export function makeDecision(id: string, overrides: Partial<Decision> = {}): Decision {
+  return {
+    id,
+    ts: TS,
+    attribution_id: `attr-${id}`,
+    action: 'active_defense_escort',
+    target: 'FRIENDLY-1',
+    rationale: `rationale ${id}`,
+    authority: 'request',
+    request_packet: null,
+    source_signal_ids: [],
+    ...overrides,
+  }
+}
+
+export function makeTrace(
+  id: string,
+  overrides: Partial<ReasoningTrace> = {},
+): ReasoningTrace {
+  return {
+    id,
+    ts: TS,
+    stage: 'fusion',
+    level: 'info',
+    message: `trace ${id}`,
+    ref_id: null,
+    payload: {},
+    ...overrides,
+  }
+}
+
+export function makeRecommendation(
+  id: string,
+  overrides: Partial<Recommendation> = {},
+): Recommendation {
+  return {
+    id,
+    summary: `recommendation ${id}`,
+    approveLabel: 'Approve',
+    ...overrides,
+  }
+}
+
+export function makeUIEvent(id: string, overrides: Partial<UIEvent> = {}): UIEvent {
+  return {
+    id,
+    ts: TS,
+    source_signal_ids: [],
+    type: 'status_update',
+    timestamp: TS,
+    severity: 'medium',
+    title: `event ${id}`,
+    message: `message ${id}`,
+    confidence: 0.6,
+    recommendation: null,
+    ...overrides,
+  }
+}
+
+export function makeRecommendationEvent(
+  id: string,
+  overrides: Partial<UIEvent> = {},
+): UIEvent {
+  return makeUIEvent(id, {
+    type: 'recommendation_created',
+    recommendation: makeRecommendation(`rec-${id}`),
+    ...overrides,
+  })
+}
+
+export function makeEmbeddingSnapshot(
+  id: string,
+  overrides: Partial<OsintEmbeddingSnapshot> = {},
+): OsintEmbeddingSnapshot {
+  return {
+    id,
+    ts: TS,
+    points: [
+      { signal_id: 's1', summary: 'p1', cluster_id: 0, x: 0.1, y: 0.2, ts: TS },
+    ],
+    cluster_count: 1,
+    similarity_threshold: 0.42,
+    model_name: 'all-MiniLM',
+    embedding_dim: 384,
+    ...overrides,
+  }
+}
+
+export function makeKBEntry(id: string, overrides: Partial<KBEntry> = {}): KBEntry {
+  return {
+    id,
+    actor: 'RED',
+    capability_type: 'co-orbital',
+    title: `kb ${id}`,
+    summary: `summary ${id}`,
+    ...overrides,
+  }
+}
+
+export function makeManeuverDemo(overrides: Partial<ManeuverDemo> = {}): ManeuverDemo {
+  return {
+    decisionId: 'dec-1',
+    startedAt: 1_700_000_000_000,
+    durationMs: 8000,
+    preMissKm: 12,
+    postMissKm: 80,
+    dvMs: 5,
+    demoType: 'evasion',
+    ...overrides,
+  }
+}

--- a/src/test/mockWebSocket.ts
+++ b/src/test/mockWebSocket.ts
@@ -1,0 +1,55 @@
+// Controllable WebSocket double for the unit suites. jsdom ships no WebSocket,
+// so tests install this via `vi.stubGlobal('WebSocket', MockWebSocket)` and
+// drive open/close/error/message events explicitly.
+//
+// close() deliberately does NOT auto-fire a 'close' event: a real close
+// handshake emits 'close' asynchronously, and the hooks call close() during
+// cleanup. Tests assert on the `closed` flag, or call emitClose() themselves
+// when they want to exercise the close handler.
+export class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static get last(): MockWebSocket | undefined {
+    return MockWebSocket.instances.at(-1)
+  }
+
+  url: string
+  closed = false
+  private listeners: Record<string, Array<(ev: unknown) => void>> = {}
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  addEventListener(type: string, cb: (ev: unknown) => void) {
+    ;(this.listeners[type] ??= []).push(cb)
+  }
+
+  removeEventListener() {}
+
+  close() {
+    this.closed = true
+  }
+
+  emitOpen() {
+    this.fire('open', {})
+  }
+
+  emitClose() {
+    this.fire('close', {})
+  }
+
+  emitError() {
+    this.fire('error', {})
+  }
+
+  emitMessage(data: unknown) {
+    this.fire('message', {
+      data: typeof data === 'string' ? data : JSON.stringify(data),
+    })
+  }
+
+  private fire(type: string, ev: unknown) {
+    for (const cb of this.listeners[type] ?? []) cb(ev)
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+// Unmount anything rendered via RTL between tests so renderHook/render in one
+// test can't leak DOM or effect state into the next.
+afterEach(() => {
+  cleanup()
+})

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,5 +21,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"],
+  "exclude": []
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+// Standalone config (not vite.config.ts) so the test runner skips the Cesium
+// static-copy plugin — none of the unit-tested modules (store, socket hooks,
+// mission-state hook) import Cesium, and copying its assets on every run would
+// be dead weight.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+    css: false,
+  },
+})


### PR DESCRIPTION
## Summary

Adds CI and a frontend test suite to a repo that previously ran nothing on push/PR and had zero frontend tests.

- **CI** (`.github/workflows/ci.yml`): on PRs and pushes to `master`, runs the Python tests (`pytest` via `uv`), `eslint`, `tsc -b`, a separate test typecheck, and the new unit tests.
- **Test tooling**: Vitest 4 + jsdom + React Testing Library + jest-dom, wired so `tsc -b` stays app-only while tests are type-checked via `tsconfig.test.json`.
- **130 tests** across the store and socket layer — `eventStore` (ring buffers, approve-banner logic, accept/defer sets, persist partialize), `useCanopySocket`/`useEngineSocket` (mock WebSocket, envelope shape-drift, reconnect backoff → fixture fallback, KB/scenario fetch), and `useCanopyMissionState` (pure derivation) — with shared fixtures and the WebSocket mock in `src/test/`.

No application code changed; all checks pass locally (130/130 frontend tests, lint, both typechecks, and the 111 existing Python tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
