### PR TITLE
Fix dead severity branch so confident attributions map to "high"

### DIFF
--- a/canopy/services/ui_events/__init__.py
+++ b/canopy/services/ui_events/__init__.py
@@ -30,6 +30,11 @@ _HIGH_SEVERITY_ACTIONS: set[Action] = {
     "space_link_interdiction_request",
 }
 
+# At or above this attribution confidence, a threat is high severity even
+# without a request. Tuned so 0.74 stays medium and 0.82 reads high
+# (see data/expected_ui_events.json).
+_HIGH_SEVERITY_CONFIDENCE = 0.75
+
 _ACTION_TITLES: dict[Action, str] = {
     "passive_defense": "Defensive posture activated",
     "active_defense_escort": "Active defense escort recommended",
@@ -57,8 +62,8 @@ def _extract_demo_beat(source_signal_ids: list[str]) -> str | None:
 def _severity_for(decision: Decision, attribution: Attribution | None) -> UISeverity:
     if decision.authority == "request" or decision.action in _HIGH_SEVERITY_ACTIONS:
         return "high"
-    if attribution is not None and attribution.confidence >= 0.75:
-        return "medium"
+    if attribution is not None and attribution.confidence >= _HIGH_SEVERITY_CONFIDENCE:
+        return "high"
     return "medium"
 
 


### PR DESCRIPTION
`_severity_for` returned `"medium"` on both arms of its confidence check, so the `attribution.confidence >= 0.75` branch was dead and a confidently-attributed threat got the same severity as a weak guess. This maps high-confidence attributions to `"high"`, matching `data/expected_ui_events.json` (0.74 → medium, 0.82 → high), and hoists the `0.75` threshold into a named `_HIGH_SEVERITY_CONFIDENCE` constant beside `_HIGH_SEVERITY_ACTIONS`. Request-authority and high-severity-action events are unchanged, and the existing `test_demo_snapshot` severity assertion still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)