### PR TITLE
Unify the Action taxonomy into one source of truth

### DIFF
--- a/canopy/services/decide/prompts.py
+++ b/canopy/services/decide/prompts.py
@@ -3,7 +3,19 @@ from __future__ import annotations
 
 from typing import Any
 
-from canopy.services.schemas.events import Attribution
+from canopy.services.schemas.events import (
+    ACTION_AUTHORITY,
+    SELECTABLE_ACTIONS,
+    Attribution,
+)
+
+# Default authority routing presented to the model, rendered from the canonical
+# tables so the prompt can't claim a routing the validator would reject. Only
+# the agent-selectable actions are shown — the offensive actions in
+# ACTION_AUTHORITY are not on the menu.
+_AUTHORITY_MENU: str = "".join(
+    f"  {action} → {ACTION_AUTHORITY[action]}\n" for action in SELECTABLE_ACTIONS
+)
 
 DECISION_TOOL: dict[str, Any] = {
     "name": "submit_decision",
@@ -25,20 +37,15 @@ DECISION_TOOL: dict[str, Any] = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": [
-                    # Passive Space Defense (Space Warfighting p.11)
-                    # These are local-authority actions by default.
-                    "passive_defense",        # EMCON, masking, hardening, posture
-                    "threat_warning",         # Urgent I&W comms to affected units
-                    "sda_tasking",            # Request SDA collection adjustment
-
-                    # Active Space Defense (Space Warfighting p.10)
-                    # These require demonstrated hostile act or hostile intent.
-                    "active_defense_escort",  # Dedicated protection, space-to-space
-
-                    # Space Link — non-kinetic, link-segment only
-                    "space_link_interdiction_request",  # EW/cyber against adversary links
-                ],
+                # Derived from schemas.events.SELECTABLE_ACTIONS — the defensive
+                # subset of the Action taxonomy. Offensive counterspace actions
+                # are deliberately absent (see the tool description above).
+                # Doctrine grouping: passive_defense / threat_warning /
+                # sda_tasking are Passive Space Defense (Space Warfighting p.11,
+                # local by default); active_defense_escort is Active Space
+                # Defense (p.10); space_link_interdiction_request is non-kinetic
+                # link-segment only.
+                "enum": list(SELECTABLE_ACTIONS),
                 "description": (
                     "Select the minimum effective defensive action. "
                     "Passive actions (passive_defense, threat_warning, sda_tasking) "
@@ -90,11 +97,7 @@ DECISION_TOOL: dict[str, Any] = {
                     "'request' = exceeds local authority; must route to CJFSCC "
                     "for engagement authority; request_packet must be populated. "
                     "Default mapping:\n"
-                    "  passive_defense → local\n"
-                    "  threat_warning → local\n"
-                    "  sda_tasking → request\n"
-                    "  active_defense_escort → request\n"
-                    "  space_link_interdiction_request → request\n"
+                    f"{_AUTHORITY_MENU}"
                     "Space Warfighting: reversible, non-kinetic defensive actions "
                     "at lower confidence may be delegated local; actions with "
                     "escalatory potential are held at higher authority."

--- a/canopy/services/decide/tools.py
+++ b/canopy/services/decide/tools.py
@@ -16,7 +16,7 @@ from typing import Any, Protocol
 
 from canopy.services.kb import KB
 from canopy.services.orbit import MIN_OPERATIONAL_LEAD_S, OrbitService
-from canopy.services.schemas.events import Action, Authority
+from canopy.services.schemas.events import ACTION_AUTHORITY, Action, Authority
 from canopy.services.traces import Tracer
 
 log = logging.getLogger(__name__)
@@ -275,19 +275,11 @@ class RequestDraftTool:
 
 # ---- routing.validate ------------------------------------------------------
 
-# Authority routing rules. Maps action → expected authority. ``request``
-# means the action requires CJFSCC approval (not local commander). Local
-# commander cannot authorise orbital effects on their own.
-_ROUTING_RULES: dict[str, Authority] = {
-    "passive_defense": "local",
-    "active_defense_escort": "request",
-    "active_defense_counterattack": "request",
-    "orbital_strike_request": "request",
-    "terrestrial_strike_request": "request",
-    "space_link_interdiction_request": "request",
-    "sda_tasking": "local",
-    "threat_warning": "local",
-}
+# Authority routing is the canonical ACTION_AUTHORITY table in schemas.events
+# (keyed over the full Action taxonomy), so this validator can't drift from the
+# actions it checks. ``request`` means the action requires CJFSCC engagement
+# authority, not the local commander; a local commander cannot authorise
+# active-defense or strike actions on their own.
 
 
 @dataclass
@@ -314,7 +306,7 @@ class RoutingValidateTool:
     async def execute(self, args: dict[str, Any], ctx: ToolContext) -> dict[str, Any]:
         action: Action = args["action"]
         authority: Authority = args["authority"]
-        expected = _ROUTING_RULES.get(action)
+        expected = ACTION_AUTHORITY.get(action)
         if expected is None:
             return {
                 "valid": False,

--- a/canopy/services/schemas/__init__.py
+++ b/canopy/services/schemas/__init__.py
@@ -1,4 +1,6 @@
 from canopy.services.schemas.events import (
+    ACTION_AUTHORITY,
+    SELECTABLE_ACTIONS,
     Action,
     Anomaly,
     Attribution,
@@ -17,6 +19,8 @@ from canopy.services.schemas.events import (
 )
 
 __all__ = [
+    "ACTION_AUTHORITY",
+    "SELECTABLE_ACTIONS",
     "Action",
     "Anomaly",
     "Attribution",

--- a/canopy/services/schemas/events.py
+++ b/canopy/services/schemas/events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -37,6 +37,61 @@ Action = Literal[
 ]
 
 Authority = Literal["local", "request"]
+
+# ---- Action taxonomy: single source of truth ------------------------------
+#
+# The ``Action`` literal above is CANOPY's complete counterspace-action
+# vocabulary; a ``Decision`` (and the decide-stage orbit enrichment, replayed
+# traces, the frontend operator panel, …) may carry any of these. Two things
+# are derived from it here so the taxonomy can't fork across the modules that
+# consume it:
+#
+#   ACTION_AUTHORITY   authority routing for *every* action. ``request`` means
+#                      the action exceeds local commander authority and must
+#                      route to the CJFSCC for engagement authority; ``local``
+#                      means it is within delegated brigade authority. Consumed
+#                      by ``decide.tools`` (``routing.validate``).
+#   SELECTABLE_ACTIONS the subset the decision agent is permitted to recommend,
+#                      in menu order. CANOPY is a defensive system: the
+#                      offensive counterspace actions (counterattack, orbital /
+#                      terrestrial strike) exist in the taxonomy so the engine
+#                      can model and route them, but must never be *selected* by
+#                      the agent. Consumed by ``decide.prompts`` as the
+#                      ``submit_decision`` tool's action enum.
+#
+# The guards below turn "add an action but forget to classify it" from a silent
+# three-way drift into an import-time error.
+ACTION_AUTHORITY: dict[Action, Authority] = {
+    "passive_defense": "local",
+    "threat_warning": "local",
+    "sda_tasking": "local",
+    "active_defense_escort": "request",
+    "space_link_interdiction_request": "request",
+    "active_defense_counterattack": "request",
+    "orbital_strike_request": "request",
+    "terrestrial_strike_request": "request",
+}
+
+SELECTABLE_ACTIONS: tuple[Action, ...] = (
+    "passive_defense",
+    "threat_warning",
+    "sda_tasking",
+    "active_defense_escort",
+    "space_link_interdiction_request",
+)
+
+_ALL_ACTIONS: frozenset[str] = frozenset(get_args(Action))
+if set(ACTION_AUTHORITY) != _ALL_ACTIONS:
+    raise RuntimeError(
+        "ACTION_AUTHORITY must route exactly the Action literal: "
+        f"missing={sorted(_ALL_ACTIONS - set(ACTION_AUTHORITY))}, "
+        f"unknown={sorted(set(ACTION_AUTHORITY) - _ALL_ACTIONS)}"
+    )
+if not set(SELECTABLE_ACTIONS) <= _ALL_ACTIONS:
+    raise RuntimeError(
+        "SELECTABLE_ACTIONS must be a subset of the Action literal: "
+        f"unknown={sorted(set(SELECTABLE_ACTIONS) - _ALL_ACTIONS)}"
+    )
 
 UIEventType = Literal["threat_updated", "recommendation_created", "status_update"]
 

--- a/tests/test_action_taxonomy.py
+++ b/tests/test_action_taxonomy.py
@@ -1,0 +1,69 @@
+"""The Action taxonomy has one source of truth.
+
+`schemas.events` owns the `Action` literal plus the two tables derived from it
+(`ACTION_AUTHORITY`, `SELECTABLE_ACTIONS`); `decide.prompts` and `decide.tools`
+must consume those rather than re-declaring their own action lists. These tests
+guard against the three-way drift that previously existed (a 5-action tool enum
+vs. an 8-action routing dict vs. the 8-action literal).
+"""
+from __future__ import annotations
+
+from typing import get_args
+
+from canopy.services.decide.prompts import DECISION_TOOL
+from canopy.services.decide.tools import RoutingValidateTool, ToolContext
+from canopy.services.kb import KB
+from canopy.services.schemas.events import (
+    ACTION_AUTHORITY,
+    SELECTABLE_ACTIONS,
+    Action,
+)
+
+# The offensive counterspace actions: in the taxonomy (so Decisions/routing can
+# model them) but never selectable by the defensive decision agent.
+OFFENSIVE_ACTIONS = {
+    "active_defense_counterattack",
+    "orbital_strike_request",
+    "terrestrial_strike_request",
+}
+
+
+def test_action_authority_covers_exactly_the_action_literal() -> None:
+    assert set(ACTION_AUTHORITY) == set(get_args(Action))
+
+
+def test_selectable_actions_are_real_defensive_actions() -> None:
+    assert set(SELECTABLE_ACTIONS) <= set(get_args(Action))
+    # The defensive subset is exactly the full taxonomy minus the offensive set.
+    assert set(SELECTABLE_ACTIONS) == set(get_args(Action)) - OFFENSIVE_ACTIONS
+    # No duplicates / stable menu order.
+    assert len(SELECTABLE_ACTIONS) == len(set(SELECTABLE_ACTIONS))
+
+
+def test_decision_tool_enum_is_derived_from_selectable_actions() -> None:
+    enum = DECISION_TOOL["input_schema"]["properties"]["action"]["enum"]
+    assert enum == list(SELECTABLE_ACTIONS)
+    # Offensive actions must not be offered to the agent.
+    assert not (set(enum) & OFFENSIVE_ACTIONS)
+
+
+def test_tool_authority_mapping_matches_canonical_table() -> None:
+    # The "Default mapping" prose in the submit_decision tool is rendered from
+    # ACTION_AUTHORITY, so it can't claim a routing the validator would reject.
+    desc = DECISION_TOOL["input_schema"]["properties"]["authority"]["description"]
+    for action in SELECTABLE_ACTIONS:
+        assert f"{action} → {ACTION_AUTHORITY[action]}" in desc
+    # The agent's menu never lists offensive actions.
+    for action in OFFENSIVE_ACTIONS:
+        assert action not in desc
+
+
+async def test_routing_validate_agrees_with_action_authority_for_all_actions() -> None:
+    tool = RoutingValidateTool()
+    ctx = ToolContext(kb=KB(entries=[]), orbit=None, tracer=None)
+    for action, expected in ACTION_AUTHORITY.items():
+        other = "request" if expected == "local" else "local"
+        good = await tool.execute({"action": action, "authority": expected}, ctx)
+        assert good["valid"] is True, action
+        bad = await tool.execute({"action": action, "authority": other}, ctx)
+        assert bad["valid"] is False, action


### PR DESCRIPTION
"Valid action" was defined three ways that had drifted apart — a 5-action `submit_decision` enum, an 8-action `_ROUTING_RULES` dict, and the 8-action `Action` literal — which left offensive-action routing rules unreachable and made the taxonomy a maintenance trap. This makes `schemas/events.py` the single source of truth: `ACTION_AUTHORITY` (authority routing over the full taxonomy) and `SELECTABLE_ACTIONS` (the defensive subset the agent may recommend) are derived from the `Action` literal and guarded at import time so they cannot silently drift. `decide/tools.py` (`routing.validate`) and `decide/prompts.py` (the `DECISION_TOOL` enum and authority mapping) now consume these instead of re-declaring their own lists. It also corrects the stale prompt text `sda_tasking → request` to match the enforced routing of `local`. Adds `tests/test_action_taxonomy.py` pinning every relationship; the suite passes (101 passed; 3 pre-existing dotenv import errors are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)