### PR TITLE
bench: emit layered metrics and immutable artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Thumbs.db
 # Bench-generated scenario variants
 bench/scorecard.json
 bench/compare/
+bench/runs/

--- a/bench/artifacts.py
+++ b/bench/artifacts.py
@@ -1,0 +1,80 @@
+"""Immutable, self-describing benchmark run bundles."""
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from bench.scoring import Scorecard
+
+
+def _git_sha() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() or "unknown"
+
+
+def _write_json_exclusive(path: Path, payload: dict) -> None:
+    with path.open("x", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+def write_run_bundle(
+    card: Scorecard,
+    *,
+    output_root: str | Path,
+    provider: str,
+    model: str,
+    suite_id: str,
+    multi_agent: bool,
+    metadata: dict | None = None,
+) -> Path:
+    """Persist an immutable run that can be inspected and rescored offline."""
+    created_at = datetime.now(UTC)
+    run_id = f"{created_at:%Y%m%dT%H%M%S%fZ}-{uuid4().hex[:8]}"
+    run_dir = Path(output_root) / f"{run_id}-{suite_id}-{provider}"
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    run_manifest = {
+        "run_id": run_id,
+        "created_at": created_at.isoformat(),
+        "git_sha": _git_sha(),
+        "suite_id": suite_id,
+        "provider": provider,
+        "model": model,
+        "multi_agent": multi_agent,
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        **(metadata or {}),
+    }
+    _write_json_exclusive(run_dir / "run.json", run_manifest)
+    _write_json_exclusive(run_dir / "summary.json", card.to_dict())
+
+    with (run_dir / "items.jsonl").open("x", encoding="utf-8") as handle:
+        for item in card.items:
+            handle.write(json.dumps(item, separators=(",", ":")))
+            handle.write("\n")
+
+    failures_dir = run_dir / "failures"
+    failures_dir.mkdir()
+    for result, item in zip(card.results, card.items, strict=False):
+        if (
+            result.actor_correct
+            and result.action_correct
+            and result.authority_correct
+            and not result.forbidden_action
+        ):
+            continue
+        case_id = result.case_id or Path(result.file).stem
+        _write_json_exclusive(failures_dir / f"{case_id}.json", item)
+
+    return run_dir

--- a/bench/compare.py
+++ b/bench/compare.py
@@ -81,6 +81,14 @@ def _print_table(scorecards: dict[str, Scorecard]) -> None:
             [
                 row("Action class accuracy", lambda c: _pct(c.action_accuracy())),
                 row("Authority routing", lambda c: _pct(c.authority_accuracy())),
+                row(
+                    "Forbidden action rate",
+                    lambda c: _pct(c.forbidden_action_rate()),
+                ),
+                row(
+                    "Unauthorized route rate",
+                    lambda c: _pct(c.unauthorized_routing_rate()),
+                ),
             ],
         ),
         (
@@ -101,6 +109,11 @@ def _print_table(scorecards: dict[str, Scorecard]) -> None:
                 row(
                     "Confidence-tier match",
                     lambda c: _pct(c.calibration_rate()),
+                ),
+                row("Brier score", lambda c: f"{c.brier_score():.3f}"),
+                row(
+                    "Expected calibration error",
+                    lambda c: f"{c.expected_calibration_error():.3f}",
                 ),
             ],
         ),
@@ -396,6 +409,10 @@ def _scorecard_from_dict(payload: dict) -> Scorecard:
                 action_correct=r["action_correct"],
                 authority_correct=r["authority_correct"],
                 calibrated=r["calibrated"],
+                forbidden_action=r.get("forbidden_action", False),
+                case_id=r.get("case_id"),
+                family=r.get("family"),
+                cluster_id=r.get("cluster_id"),
             )
         )
     return card

--- a/bench/run.py
+++ b/bench/run.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from bench import generate as bench_generate
+from bench.artifacts import write_run_bundle
 from bench.runner import run_trial
 from bench.specs import load_scenario_registry
 from bench.scoring import (
@@ -57,14 +58,20 @@ def _label_outputs(
     pred_action = decision.action if decision else None
     pred_authority = decision.authority if decision else None
 
+    expected_actors = label.get("expected_actors", label["expected_actor"])
+    expected_actions = label.get("expected_actions", label["expected_action"])
+    expected_authorities = label.get(
+        "expected_authorities", label["expected_authority"]
+    )
+
     actor_correct = pred_actor is not None and actor_match(
-        pred_actor, label["expected_actor"]
+        pred_actor, expected_actors
     )
     action_correct = pred_action is not None and action_match(
-        pred_action, label["expected_action"]
+        pred_action, expected_actions
     )
     authority_correct = pred_authority is not None and authority_match(
-        pred_authority, label["expected_authority"]
+        pred_authority, expected_authorities
     )
     calibrated = pred_conf is not None and confidence_band_match(
         pred_conf, label.get("confidence_band", "med")
@@ -85,6 +92,10 @@ def _label_outputs(
         action_correct=action_correct,
         authority_correct=authority_correct,
         calibrated=calibrated,
+        forbidden_action=pred_action in label.get("forbidden_actions", []),
+        case_id=label.get("case_id"),
+        family=label.get("family"),
+        cluster_id=label.get("cluster_id"),
     )
 
 
@@ -96,9 +107,16 @@ def _seed_labels() -> list[dict[str, Any]]:
             {
                 "file": case.file,
                 "expected_actor": expected.actors[0],
+                "expected_actors": expected.actors,
                 "expected_action": expected.actions[0],
+                "expected_actions": expected.actions,
                 "expected_authority": expected.authorities[0],
+                "expected_authorities": expected.authorities,
                 "confidence_band": expected.confidence_band,
+                "forbidden_actions": expected.forbidden_actions,
+                "case_id": case.id,
+                "family": case.family,
+                "cluster_id": case.id,
                 "_path": str(case.scenario_path),
                 "_case": case,
             }
@@ -117,7 +135,13 @@ def _variant_labels() -> list[dict[str, Any]]:
         path = (BENCH_DIR / rel).resolve()
         if not path.exists():
             continue
-        out.append({**entry, "_path": str(path)})
+        out.append(
+            {
+                **entry,
+                "_path": str(path),
+                "cluster_id": Path(entry.get("seed_file", rel)).stem,
+            }
+        )
     return out
 
 
@@ -158,7 +182,26 @@ async def _run(
         result = _label_outputs(
             label, trial.captured(), trial.elapsed_seconds
         )
-        scorecard.append(result)
+        item = trial.to_dict()
+        item.update(
+            {
+                "case_id": result.case_id or Path(label["file"]).stem,
+                "family": result.family,
+                "expected": {
+                    "actors": label.get(
+                        "expected_actors", [label["expected_actor"]]
+                    ),
+                    "actions": label.get(
+                        "expected_actions", [label["expected_action"]]
+                    ),
+                    "authorities": label.get(
+                        "expected_authorities", [label["expected_authority"]]
+                    ),
+                    "forbidden_actions": label.get("forbidden_actions", []),
+                },
+            }
+        )
+        scorecard.append(result, item=item)
         log.info(
             "  [%d/%d] %-50s  actor=%s%s  action=%s%s  "
             "auth=%s%s  conf=%s",
@@ -206,6 +249,16 @@ def _print_report(card: Scorecard) -> None:
         f"  Confidence calibration tier: {card.correct('calibrated')}/{card.total} "
         f"= {card.calibration_rate() * 100:.0f}%"
     )
+    print(
+        f"  Brier score: {card.brier_score():.3f}, "
+        f"ECE: {card.expected_calibration_error():.3f}"
+    )
+    print(
+        f"Policy violations: forbidden actions "
+        f"{card.forbidden_action_rate() * 100:.1f}%, unauthorized routing "
+        f"{card.unauthorized_routing_rate() * 100:.1f}%"
+    )
+    print(f"Completion rate: {card.completion_rate() * 100:.1f}%")
     print(f"Latency p50: {card.latency_p(0.5):.2f}s, p95: {card.latency_p(0.95):.2f}s")
     print("=" * 60)
 
@@ -241,8 +294,17 @@ def main() -> int:
     )
 
     SCORECARD.write_text(json.dumps(card.to_dict(), indent=2))
+    bundle = write_run_bundle(
+        card,
+        output_root=BENCH_DIR / "runs",
+        provider=provider,
+        model=provider,
+        suite_id="canopy-public-v1",
+        multi_agent=not args.no_redteam,
+    )
     _print_report(card)
     print(f"Scorecard written to {SCORECARD.relative_to(ROOT)}")
+    print(f"Immutable run bundle written to {bundle.relative_to(ROOT)}")
 
     # Stub LLM is deterministic — actor accuracy is bounded by the
     # _KIND_TO_ATTRIBUTION mapping. Live providers should clear ≥0.50;

--- a/bench/runner.py
+++ b/bench/runner.py
@@ -12,6 +12,7 @@ from canopy.services.schemas.events import (
     Anomaly,
     Attribution,
     Decision,
+    ReasoningTrace,
     Signal,
     UIEvent,
 )
@@ -32,6 +33,8 @@ class TrialArtifact:
     attributions: list[Attribution] = field(default_factory=list)
     decisions: list[Decision] = field(default_factory=list)
     ui_events: list[UIEvent] = field(default_factory=list)
+    traces: list[ReasoningTrace] = field(default_factory=list)
+    errors: list[dict[str, str]] = field(default_factory=list)
 
     @property
     def anomaly_source_signal_ids(self) -> list[str]:
@@ -50,6 +53,21 @@ class TrialArtifact:
             "attribution": self.attributions,
             "decision": self.decisions,
             "ui_event": self.ui_events,
+        }
+
+    def to_dict(self) -> dict:
+        return {
+            "scenario": str(self.scenario),
+            "elapsed_seconds": self.elapsed_seconds,
+            "signals": [item.model_dump(mode="json") for item in self.signals],
+            "anomalies": [item.model_dump(mode="json") for item in self.anomalies],
+            "attributions": [
+                item.model_dump(mode="json") for item in self.attributions
+            ],
+            "decisions": [item.model_dump(mode="json") for item in self.decisions],
+            "ui_events": [item.model_dump(mode="json") for item in self.ui_events],
+            "traces": [item.model_dump(mode="json") for item in self.traces],
+            "errors": self.errors,
         }
 
 
@@ -93,6 +111,7 @@ async def run_trial(
         ),
         asyncio.create_task(consume("decisions.*", artifact.decisions, Decision)),
         asyncio.create_task(consume("ui_events.*", artifact.ui_events, UIEvent)),
+        asyncio.create_task(consume("traces.*", artifact.traces, ReasoningTrace)),
     ]
 
     async def execute() -> None:
@@ -114,7 +133,16 @@ async def run_trial(
 
     started = time.perf_counter()
     try:
-        await asyncio.wait_for(execute(), timeout=timeout_s)
+        try:
+            await asyncio.wait_for(execute(), timeout=timeout_s)
+        except TimeoutError:
+            artifact.errors.append(
+                {
+                    "stage": "trial",
+                    "type": "timeout",
+                    "message": f"trial exceeded {timeout_s:.1f}s",
+                }
+            )
     finally:
         artifact.elapsed_seconds = time.perf_counter() - started
         for task in (*capture_tasks, *service_tasks):

--- a/bench/scoring.py
+++ b/bench/scoring.py
@@ -6,8 +6,12 @@ calibration scoring.
 """
 from __future__ import annotations
 
+import random
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Literal
+
+from canopy.services.schemas.events import ACTION_AUTHORITY
 
 ConfidenceBand = Literal["low", "med", "high"]
 
@@ -16,8 +20,14 @@ def actor_head(actor: str) -> str:
     return (actor or "").split("/", 1)[0].strip().lower()
 
 
-def actor_match(predicted: str, expected: str) -> bool:
-    return actor_head(predicted) == actor_head(expected)
+def _accepted(expected: str | Iterable[str]) -> list[str]:
+    return [expected] if isinstance(expected, str) else list(expected)
+
+
+def actor_match(predicted: str, expected: str | Iterable[str]) -> bool:
+    return actor_head(predicted) in {
+        actor_head(item) for item in _accepted(expected)
+    }
 
 
 def confidence_band(confidence: float) -> ConfidenceBand:
@@ -34,16 +44,18 @@ def confidence_band_match(confidence: float, expected: ConfidenceBand) -> bool:
     return confidence_band(confidence) == expected
 
 
-def action_match(predicted: str, expected: str) -> bool:
-    if expected in ("any", "*"):
+def action_match(predicted: str, expected: str | Iterable[str]) -> bool:
+    accepted = _accepted(expected)
+    if any(item in ("any", "*") for item in accepted):
         return predicted not in ("", "threat_warning")
-    return predicted == expected
+    return predicted in accepted
 
 
-def authority_match(predicted: str, expected: str) -> bool:
-    if expected in ("any", "*"):
+def authority_match(predicted: str, expected: str | Iterable[str]) -> bool:
+    accepted = _accepted(expected)
+    if any(item in ("any", "*") for item in accepted):
         return predicted != ""
-    return predicted == expected
+    return predicted in accepted
 
 
 @dataclass
@@ -62,14 +74,21 @@ class ScenarioResult:
     action_correct: bool
     authority_correct: bool
     calibrated: bool
+    forbidden_action: bool = False
+    case_id: str | None = None
+    family: str | None = None
+    cluster_id: str | None = None
 
 
 @dataclass
 class Scorecard:
     results: list[ScenarioResult] = field(default_factory=list)
+    items: list[dict] = field(default_factory=list, repr=False)
 
-    def append(self, r: ScenarioResult) -> None:
+    def append(self, r: ScenarioResult, *, item: dict | None = None) -> None:
         self.results.append(r)
+        if item is not None:
+            self.items.append(item)
 
     @property
     def total(self) -> int:
@@ -89,6 +108,159 @@ class Scorecard:
 
     def calibration_rate(self) -> float:
         return self.correct("calibrated") / self.total if self.total else 0.0
+
+    def completion_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        complete = sum(
+            1
+            for r in self.results
+            if r.predicted_actor is not None
+            and r.predicted_action is not None
+            and r.predicted_authority is not None
+            and r.confidence is not None
+        )
+        return complete / self.total
+
+    def forbidden_action_rate(self) -> float:
+        return (
+            self.correct("forbidden_action") / self.total if self.total else 0.0
+        )
+
+    def unauthorized_routing_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        violations = 0
+        for result in self.results:
+            if result.predicted_action is None or result.predicted_authority is None:
+                continue
+            expected = ACTION_AUTHORITY.get(result.predicted_action)  # type: ignore[arg-type]
+            if expected is not None and result.predicted_authority != expected:
+                violations += 1
+        return violations / self.total
+
+    def brier_score(self) -> float:
+        scored = [r for r in self.results if r.confidence is not None]
+        if not scored:
+            return 0.0
+        return sum(
+            (float(r.confidence) - float(r.actor_correct)) ** 2 for r in scored
+        ) / len(scored)
+
+    def expected_calibration_error(self) -> float:
+        scored = [r for r in self.results if r.confidence is not None]
+        if not scored:
+            return 0.0
+        bins = ((0.0, 0.5), (0.5, 0.7), (0.7, 0.85), (0.85, 1.01))
+        error = 0.0
+        for lo, hi in bins:
+            members = [r for r in scored if lo <= float(r.confidence) < hi]
+            if not members:
+                continue
+            accuracy = sum(r.actor_correct for r in members) / len(members)
+            mean_confidence = sum(float(r.confidence) for r in members) / len(members)
+            error += (len(members) / len(scored)) * abs(
+                accuracy - mean_confidence
+            )
+        return error
+
+    def actor_macro_f1(self) -> float:
+        if not self.results:
+            return 0.0
+        classes = {
+            actor_head(actor)
+            for result in self.results
+            for actor in (result.expected_actor, result.predicted_actor or "")
+            if actor
+        }
+        scores: list[float] = []
+        for actor in classes:
+            tp = sum(
+                actor_head(r.expected_actor) == actor
+                and actor_head(r.predicted_actor or "") == actor
+                for r in self.results
+            )
+            fp = sum(
+                actor_head(r.expected_actor) != actor
+                and actor_head(r.predicted_actor or "") == actor
+                for r in self.results
+            )
+            fn = sum(
+                actor_head(r.expected_actor) == actor
+                and actor_head(r.predicted_actor or "") != actor
+                for r in self.results
+            )
+            denominator = 2 * tp + fp + fn
+            scores.append((2 * tp / denominator) if denominator else 0.0)
+        return sum(scores) / len(scores) if scores else 0.0
+
+    def abstention_metrics(self) -> dict[str, float]:
+        predicted = [actor_head(r.predicted_actor or "") == "unknown" for r in self.results]
+        expected = [actor_head(r.expected_actor) == "unknown" for r in self.results]
+        tp = sum(p and e for p, e in zip(predicted, expected, strict=True))
+        predicted_count = sum(predicted)
+        expected_count = sum(expected)
+        return {
+            "precision": tp / predicted_count if predicted_count else 0.0,
+            "recall": tp / expected_count if expected_count else 0.0,
+        }
+
+    def risk_coverage_curve(self) -> list[dict[str, float]]:
+        curve = []
+        for threshold in (0.0, 0.5, 0.7, 0.85):
+            committed = [
+                r for r in self.results if (r.confidence or 0.0) >= threshold
+            ]
+            curve.append(
+                {
+                    "threshold": threshold,
+                    "coverage": len(committed) / self.total if self.total else 0.0,
+                    "accuracy": (
+                        sum(r.actor_correct for r in committed) / len(committed)
+                        if committed
+                        else 0.0
+                    ),
+                }
+            )
+        return curve
+
+    def bootstrap_intervals(
+        self, *, iterations: int = 1000, seed: int = 1337
+    ) -> dict[str, dict[str, float]]:
+        """Case-clustered bootstrap intervals for primary accuracy metrics."""
+        if not self.results:
+            return {}
+        clusters: dict[str, list[ScenarioResult]] = {}
+        for result in self.results:
+            key = result.cluster_id or result.case_id or result.file
+            clusters.setdefault(key, []).append(result)
+        keys = sorted(clusters)
+        rng = random.Random(seed)
+        samples: dict[str, list[float]] = {
+            "attribution_accuracy": [],
+            "action_accuracy": [],
+            "authority_accuracy": [],
+        }
+        attrs = {
+            "attribution_accuracy": "actor_correct",
+            "action_accuracy": "action_correct",
+            "authority_accuracy": "authority_correct",
+        }
+        for _ in range(iterations):
+            selected = [rng.choice(keys) for _ in keys]
+            rows = [row for key in selected for row in clusters[key]]
+            for metric, attr in attrs.items():
+                samples[metric].append(
+                    sum(bool(getattr(row, attr)) for row in rows) / len(rows)
+                )
+
+        intervals = {}
+        for metric, values in samples.items():
+            values.sort()
+            lo = values[int(0.025 * (len(values) - 1))]
+            hi = values[int(0.975 * (len(values) - 1))]
+            intervals[metric] = {"low": round(lo, 3), "high": round(hi, 3)}
+        return intervals
 
     def latency_p(self, p: float) -> float:
         if not self.results:
@@ -179,6 +351,25 @@ class Scorecard:
             "action_accuracy": round(self.action_accuracy(), 3),
             "authority_accuracy": round(self.authority_accuracy(), 3),
             "calibration_rate": round(self.calibration_rate(), 3),
+            "completion_rate": round(self.completion_rate(), 3),
+            "brier_score": round(self.brier_score(), 3),
+            "expected_calibration_error": round(
+                self.expected_calibration_error(), 3
+            ),
+            "actor_macro_f1": round(self.actor_macro_f1(), 3),
+            "abstention": {
+                key: round(value, 3)
+                for key, value in self.abstention_metrics().items()
+            },
+            "risk_coverage_curve": [
+                {key: round(value, 3) for key, value in point.items()}
+                for point in self.risk_coverage_curve()
+            ],
+            "bootstrap_95": self.bootstrap_intervals(),
+            "forbidden_action_rate": round(self.forbidden_action_rate(), 3),
+            "unauthorized_routing_rate": round(
+                self.unauthorized_routing_rate(), 3
+            ),
             "commit_rate_at_55": round(self.commit_rate(0.55), 3),
             "accuracy_when_committed_55": round(self.accuracy_when_committed(0.55), 3),
             "hallucination_rate_at_70": round(self.hallucination_rate(0.70), 3),
@@ -204,6 +395,10 @@ class Scorecard:
                     "action_correct": r.action_correct,
                     "authority_correct": r.authority_correct,
                     "calibrated": r.calibrated,
+                    "forbidden_action": r.forbidden_action,
+                    "case_id": r.case_id,
+                    "family": r.family,
+                    "cluster_id": r.cluster_id,
                 }
                 for r in self.results
             ],

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -30,6 +30,7 @@ from bench.scoring import (
 def test_actor_match_handles_actor_head():
     assert actor_match("Russia / GRU", "russia")
     assert actor_match("CHINA / PLA SSF", "China")
+    assert actor_match("China / PLA SSF", ["Russia", "China"])
     assert not actor_match("Iran", "Russia")
 
 

--- a/tests/test_benchmark_artifacts.py
+++ b/tests/test_benchmark_artifacts.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bench.artifacts import write_run_bundle
+from bench.scoring import ScenarioResult, Scorecard
+
+
+def _result(*, correct: bool, confidence: float, action: str = "passive_defense"):
+    return ScenarioResult(
+        file="case.jsonl",
+        expected_actor="China",
+        predicted_actor="China" if correct else "Russia",
+        expected_action="passive_defense",
+        predicted_action=action,
+        expected_authority="local",
+        predicted_authority="local",
+        confidence=confidence,
+        expected_confidence_band="med",
+        latency_seconds=0.25,
+        actor_correct=correct,
+        action_correct=action == "passive_defense",
+        authority_correct=True,
+        calibrated=True,
+    )
+
+
+def test_scorecard_reports_statistical_calibration_and_policy_metrics() -> None:
+    card = Scorecard()
+    card.append(_result(correct=True, confidence=0.8))
+    card.append(
+        _result(
+            correct=False,
+            confidence=0.6,
+            action="active_defense_escort",
+        )
+    )
+
+    assert card.brier_score() == pytest.approx(0.2)
+    assert card.expected_calibration_error() == pytest.approx(0.4)
+    assert card.completion_rate() == 1.0
+    assert card.unauthorized_routing_rate() == 0.5
+    assert card.to_dict()["bootstrap_95"]["attribution_accuracy"] == {
+        "low": 0.5,
+        "high": 0.5,
+    }
+
+
+def test_run_bundle_is_immutable_and_rescoreable(tmp_path) -> None:
+    card = Scorecard()
+    result = _result(correct=True, confidence=0.8)
+    card.append(result, item={"case_id": "case-1", "traces": [{"stage": "fusion"}]})
+
+    bundle = write_run_bundle(
+        card,
+        output_root=tmp_path,
+        provider="stub",
+        model="deterministic-control",
+        suite_id="test-suite",
+        multi_agent=True,
+    )
+
+    run = json.loads((bundle / "run.json").read_text())
+    summary = json.loads((bundle / "summary.json").read_text())
+    items = [json.loads(line) for line in (bundle / "items.jsonl").read_text().splitlines()]
+
+    assert run["provider"] == "stub"
+    assert run["suite_id"] == "test-suite"
+    assert run["git_sha"]
+    assert summary["brier_score"] == 0.04
+    assert items == [{"case_id": "case-1", "traces": [{"stage": "fusion"}]}]
+
+    second = write_run_bundle(
+        card,
+        output_root=tmp_path,
+        provider="stub",
+        model="deterministic-control",
+        suite_id="test-suite",
+        multi_agent=True,
+    )
+    assert second != bundle


### PR DESCRIPTION
## Summary
- add completion, calibration, abstention, macro-F1, policy, risk-coverage, and clustered-bootstrap metrics
- persist immutable run manifests, item-level outputs/traces/errors, summaries, and failure bundles
- make timeout and missing outputs explicit evaluation failures
- extend comparison reconstruction for the richer scorecard

## Verification
- 21 focused benchmark/artifact tests passed
- Python compile and diff checks passed

Stacked on the scenario/model registry PR.